### PR TITLE
Pass ID of entity to rendered RootComponent

### DIFF
--- a/packages/peregrine/src/Router/MagentoRouteHandler.js
+++ b/packages/peregrine/src/Router/MagentoRouteHandler.js
@@ -36,18 +36,22 @@ export default class MagentoRouteHandler extends Component {
             apiBase,
             __tmp_webpack_public_path__
         })
-            .then(({ rootChunkID, rootModuleID, matched }) => {
+            .then(({ rootChunkID, rootModuleID, matched, id }) => {
                 if (!matched) {
                     // TODO: User-defined 404 page
                     // when the API work is done to support it
                     throw new Error('404');
                 }
-                return fetchRootComponent(rootChunkID, rootModuleID);
-            })
-            .then(Component => {
-                this.setState({
-                    [pathname]: Component
-                });
+                return fetchRootComponent(rootChunkID, rootModuleID).then(
+                    Component => {
+                        this.setState({
+                            [pathname]: {
+                                Component,
+                                id
+                            }
+                        });
+                    }
+                );
             })
             .catch(err => {
                 console.log('Routing resolve failed\n', err);
@@ -56,13 +60,15 @@ export default class MagentoRouteHandler extends Component {
 
     render() {
         const { location } = this.props;
-        const Page = this.state[location.pathname];
+        const routeInfo = this.state[location.pathname];
 
-        if (!Page) {
+        if (!routeInfo) {
             // TODO (future iteration): User-defined loading content
             return <div>Loading</div>;
         }
 
-        return <Page />;
+        const { Component, ...routeProps } = routeInfo;
+
+        return <Component {...routeProps} />;
     }
 }

--- a/packages/peregrine/src/Router/__tests__/MagentoRouteHandler.test.js
+++ b/packages/peregrine/src/Router/__tests__/MagentoRouteHandler.test.js
@@ -15,7 +15,8 @@ const mockUnknownRouteResolverOnce = () =>
         Promise.resolve({
             rootChunkID: 0,
             rootModuleID: 1,
-            matched: true
+            matched: true,
+            id: 1
         })
     );
 const mockFetchRootComponentOnce = Component =>
@@ -35,7 +36,9 @@ test('Does not re-fetch route that has already been seen', cb => {
     );
     wrapper.setState({
         // Populate state with a pre-visited route
-        '/second-path.html': SecondRouteComponent
+        '/second-path.html': {
+            Component: SecondRouteComponent
+        }
     });
     process.nextTick(() => {
         wrapper.update();

--- a/packages/peregrine/src/Router/__tests__/Router.test.js
+++ b/packages/peregrine/src/Router/__tests__/Router.test.js
@@ -16,7 +16,8 @@ const mockUnknownRouteResolverOnce = () =>
         Promise.resolve({
             rootChunkID: 0,
             rootModuleID: 1,
-            matched: true
+            matched: true,
+            id: 1
         })
     );
 

--- a/packages/peregrine/src/Router/resolveUnknownRoute.js
+++ b/packages/peregrine/src/Router/resolveUnknownRoute.js
@@ -2,7 +2,7 @@
  * @description Given a route string, resolves with the "standard route", along
  * with the assigned Root Component (and its owning chunk) from the backend
  * @param {{ route: string, apiBase: string, __tmp_webpack_public_path__: string}} opts
- * @returns {Promise<{matched: boolean, rootChunkID: number | undefined, rootModuleID: number | undefined }>}
+ * @returns {Promise<{matched: boolean, rootChunkID: number | undefined, rootModuleID: number | undefined, id: number }>}
  */
 export default function resolveUnknownRoute(opts) {
     const { route, apiBase, __tmp_webpack_public_path__ } = opts;
@@ -20,6 +20,7 @@ export default function resolveUnknownRoute(opts) {
         ).then(({ rootChunkID, rootModuleID }) => ({
             rootChunkID,
             rootModuleID,
+            id: res.id,
             matched: true
         }));
     });
@@ -43,6 +44,7 @@ function remotelyResolveRoute(opts) {
                 {
                     urlResolver(url: "${opts.route}") {
                         type
+                        id
                     }
                 }
             `.trim()


### PR DESCRIPTION
<!-- (REQUIRED) What is the nature of this PR? -->

## This PR is a:

[ ] New feature
[X] Enhancement/Optimization
[ ] Refactor
[ ] Bugfix
[ ] Test for existing code
[ ] Documentation

<!-- (REQUIRED) What does this PR change? -->

## Summary

This passes the ID of the entity being viewed to the RootComponent. This should make it easier to craft GraphQL queries based on the ID, without needing to do manual URL parsing of the customer-facing URLs in the individual roots.

![image](https://user-images.githubusercontent.com/5233399/41987998-2a5dc900-7a3b-11e8-9f3f-c19101f33ac4.png)


<!-- (OPTIONAL) What other information can you provide about this PR? -->

## Additional information

<!--
Thank you for your contribution!

Before submitting this pull request, please make sure you have read our Contribution Guidelines and your PR meets our contribution standards:
https://github.com/magento-research/pwa-studio/blob/master/.github/CONTRIBUTION.md

Please fill out as much information as you can about your PR to help speed up the review process.
If your PR addresses an existing GitHub Issue, please refer to it in the title or Additional Information section to make the connection.

We may ask you for changes in your PR in order to meet the standards set in our Contribution Guidelines. PR's that do not comply with our guidelines may be closed at the maintainers' discretion.

Feel free to remove this section before creating this PR.
-->
