### PR TITLE
Same PHP version dependencies as Magento 2.3

### DIFF
--- a/packages/venia-concept/composer.json
+++ b/packages/venia-concept/composer.json
@@ -2,7 +2,7 @@
   "name": "magento/theme-frontend-venia",
   "description": "Venia PWA Concept Theme for Magento 2",
   "require": {
-    "php": "7.0.2|7.0.4|~7.0.6|~7.1.0",
+    "php": "~7.1.3||~7.2.0",
     "magento-research/theme-frontend-pwa": "*"
   },
   "type": "magento2-theme",


### PR DESCRIPTION
## This PR is a:

- [ ] New feature
- [x] Enhancement/Optimization
- [ ] Refactor
- [ ] Bugfix
- [ ] Test for existing code
- [ ] Documentation

## Summary

Composer cannot install the Venia theme in a PHP 7.2 environment. The assumption I've made here is that it's fine for the theme to have the same language requirements as Magento itself, i.e. https://github.com/magento/magento2/blob/2.3-develop/composer.json#L14