### PR TITLE
style(css): Configure prettier to format CSS

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
     "test": "jest",
     "test:debug": "node --inspect-brk node_modules/.bin/jest -i --watch",
     "test:dev": "jest --watch",
-    "prettier": "prettier --write 'packages/**/*.js' '*.js'",
-    "prettier:check": "prettier --list-different 'packages/**/*.js' '*.js'"
+    "prettier": "prettier --write 'packages/**/*.@(js|css)' '*.js'",
+    "prettier:check": "prettier --list-different 'packages/**/*.@(js|css)' '*.js'"
   },
   "devDependencies": {
     "@magento/eslint-config": "^1.0.0",

--- a/packages/venia-concept/src/RootComponents/Category/category.css
+++ b/packages/venia-concept/src/RootComponents/Category/category.css
@@ -1,10 +1,10 @@
 .root {
-  padding: 1rem;
+    padding: 1rem;
 }
 
 .title {
-  font-size: 1.5rem;
-  font-weight: 400;
-  margin: 0 0 1rem;
-  padding: 0.5rem;
+    font-size: 1.5rem;
+    font-weight: 400;
+    margin: 0 0 1rem;
+    padding: 0.5rem;
 }

--- a/packages/venia-concept/src/components/Button/button.css
+++ b/packages/venia-concept/src/components/Button/button.css
@@ -1,33 +1,33 @@
 .root {
-  composes: root from "../clickable.css";
-  background-color: white;
-  border: 1px solid currentColor;
-  border-radius: 1.5rem;
-  color: rgb(var(--venia-teal));
-  font-size: 0.875rem;
-  height: 3rem;
-  min-width: 8.75rem;
-  padding: 0 1.5rem;
-  transition: opacity 256ms linear;
+    composes: root from '../clickable.css';
+    background-color: white;
+    border: 1px solid currentColor;
+    border-radius: 1.5rem;
+    color: rgb(var(--venia-teal));
+    font-size: 0.875rem;
+    height: 3rem;
+    min-width: 8.75rem;
+    padding: 0 1.5rem;
+    transition: opacity 256ms linear;
 }
 
 .root:hover {
-  background-color: rgb(var(--venia-teal-alt));
+    background-color: rgb(var(--venia-teal-alt));
 }
 
 .root[disabled] {
-  filter: grayscale(1);
-  opacity: 0.38;
-  pointer-events: none;
+    filter: grayscale(1);
+    opacity: 0.38;
+    pointer-events: none;
 }
 
 .content {
-  align-items: center;
-  display: inline-grid;
-  grid-auto-columns: auto;
-  grid-auto-flow: column;
-  grid-gap: 0.5rem;
-  grid-template-rows: auto;
-  justify-content: center;
-  justify-items: center;
+    align-items: center;
+    display: inline-grid;
+    grid-auto-columns: auto;
+    grid-auto-flow: column;
+    grid-gap: 0.5rem;
+    grid-template-rows: auto;
+    justify-content: center;
+    justify-items: center;
 }

--- a/packages/venia-concept/src/components/CategoryList/categoryList.css
+++ b/packages/venia-concept/src/components/CategoryList/categoryList.css
@@ -32,7 +32,7 @@
     height: 5rem;
     margin: 0 auto 1rem auto;
     overflow: hidden;
-    padding: .5rem;
+    padding: 0.5rem;
     width: 5rem;
 }
 

--- a/packages/venia-concept/src/components/Footer/footer.css
+++ b/packages/venia-concept/src/components/Footer/footer.css
@@ -1,30 +1,30 @@
 .root {
-  background-color: rgb(var(--venia-grey));
-  border-top: 1px solid rgb(var(--venia-border));
-  color: black;
-  margin-top: 1rem;
-  padding: 0 1rem;
+    background-color: rgb(var(--venia-grey));
+    border-top: 1px solid rgb(var(--venia-border));
+    color: black;
+    margin-top: 1rem;
+    padding: 0 1rem;
 }
 
 .tile {
-  border-bottom: 1px solid rgb(var(--venia-border));
-  padding: 1rem 2rem;
+    border-bottom: 1px solid rgb(var(--venia-border));
+    padding: 1rem 2rem;
 }
 
 .tileTitle {
-  font-size: 1.25rem;
-  margin: 1rem 0;
+    font-size: 1.25rem;
+    margin: 1rem 0;
 }
 
 .tileBody {
-  font-size: 0.875rem;
-  line-height: 1.25rem;
-  margin: 1rem 0;
+    font-size: 0.875rem;
+    line-height: 1.25rem;
+    margin: 1rem 0;
 }
 
 .copyright {
-  color: rgb(var(--venia-text-alt));
-  font-size: 0.75rem;
-  padding: 1.5rem 2rem;
-  text-align: center;
+    color: rgb(var(--venia-text-alt));
+    font-size: 0.75rem;
+    padding: 1.5rem 2rem;
+    text-align: center;
 }

--- a/packages/venia-concept/src/components/Gallery/gallery.css
+++ b/packages/venia-concept/src/components/Gallery/gallery.css
@@ -1,42 +1,42 @@
 .root {
-  display: grid;
-  grid-template-areas:
-    "actions"
-    "items"
-    "pagination";
-  grid-template-columns: 1fr;
-  line-height: 1;
+    display: grid;
+    grid-template-areas:
+        'actions'
+        'items'
+        'pagination';
+    grid-template-columns: 1fr;
+    line-height: 1;
 }
 
 .actions {
-  display: grid;
-  grid-area: actions;
-  grid-auto-columns: auto;
-  grid-auto-flow: column;
-  grid-column-gap: 1rem;
-  justify-content: center;
-  padding-bottom: 1rem;
+    display: grid;
+    grid-area: actions;
+    grid-auto-columns: auto;
+    grid-auto-flow: column;
+    grid-column-gap: 1rem;
+    justify-content: center;
+    padding-bottom: 1rem;
 }
 
 .items {
-  display: grid;
-  grid-area: items;
-  grid-gap: 1rem;
-  grid-template-columns: repeat(3, 1fr);
+    display: grid;
+    grid-area: items;
+    grid-gap: 1rem;
+    grid-template-columns: repeat(3, 1fr);
 }
 
 @media (max-width: 640px) {
-  .items {
-    grid-template-columns: repeat(2, 1fr);
-  }
+    .items {
+        grid-template-columns: repeat(2, 1fr);
+    }
 }
 
 .pagination {
-  display: grid;
-  grid-area: pagination;
-  grid-auto-columns: auto;
-  grid-auto-flow: column;
-  grid-column-gap: 1rem;
-  justify-content: center;
-  padding-top: 1rem;
+    display: grid;
+    grid-area: pagination;
+    grid-auto-columns: auto;
+    grid-auto-flow: column;
+    grid-column-gap: 1rem;
+    justify-content: center;
+    padding-top: 1rem;
 }

--- a/packages/venia-concept/src/components/Gallery/item.css
+++ b/packages/venia-concept/src/components/Gallery/item.css
@@ -1,62 +1,63 @@
-.root {}
+.root {
+}
 
 .images {
-  display: grid;
-  grid-template-areas: "main";
+    display: grid;
+    grid-template-areas: 'main';
 }
 
 .image {
-  display: block;
-  grid-area: main;
-  height: auto;
-  opacity: 1;
-  transition-duration: 512ms;
-  transition-property: opacity, visibility;
-  transition-timing-function: ease-out;
-  visibility: visible;
-  width: 100%;
+    display: block;
+    grid-area: main;
+    height: auto;
+    opacity: 1;
+    transition-duration: 512ms;
+    transition-property: opacity, visibility;
+    transition-timing-function: ease-out;
+    visibility: visible;
+    width: 100%;
 }
 
 .imagePlaceholder {
-  composes: image;
-  background-color: rgb(var(--venia-grey));
+    composes: image;
+    background-color: rgb(var(--venia-grey));
 }
 
 .name,
 .price {
-  font-size: 0.875rem;
-  line-height: 1rem;
-  margin: 0.5rem 0;
-  min-height: 1rem;
+    font-size: 0.875rem;
+    line-height: 1rem;
+    margin: 0.5rem 0;
+    min-height: 1rem;
 }
 
 /* state: pending */
 
 .root_pending {
-  composes: root;
+    composes: root;
 }
 
 .images_pending {
-  composes: images;
+    composes: images;
 }
 
 .image_pending {
-  composes: image;
-  opacity: 0;
-  visibility: hidden;
+    composes: image;
+    opacity: 0;
+    visibility: hidden;
 }
 
 .imagePlaceholder_pending {
-  composes: imagePlaceholder;
+    composes: imagePlaceholder;
 }
 
 .name_pending {
-  composes: name;
-  background-color: rgb(var(--venia-grey));
+    composes: name;
+    background-color: rgb(var(--venia-grey));
 }
 
 .price_pending {
-  composes: price;
-  background-color: rgb(var(--venia-grey));
-  width: 3rem;
+    composes: price;
+    background-color: rgb(var(--venia-grey));
+    width: 3rem;
 }

--- a/packages/venia-concept/src/components/Header/cartTrigger.css
+++ b/packages/venia-concept/src/components/Header/cartTrigger.css
@@ -1,5 +1,5 @@
 .root {
-  composes: root from "../clickable.css";
-  height: 3rem;
-  width: 3rem;
+    composes: root from '../clickable.css';
+    height: 3rem;
+    width: 3rem;
 }

--- a/packages/venia-concept/src/components/Header/header.css
+++ b/packages/venia-concept/src/components/Header/header.css
@@ -1,64 +1,63 @@
 .root {
-  background-color: rgb(var(--venia-grey));
-  box-shadow: 0 1px rgb(var(--venia-border));
-  display: grid;
-  grid-auto-columns: 100%;
-  grid-auto-flow: row;
-  grid-auto-rows: auto;
-  grid-row-gap: 0.5rem;
+    background-color: rgb(var(--venia-grey));
+    box-shadow: 0 1px rgb(var(--venia-border));
+    display: grid;
+    grid-auto-columns: 100%;
+    grid-auto-flow: row;
+    grid-auto-rows: auto;
+    grid-row-gap: 0.5rem;
 }
 
 .toolbar {
-  align-content: center;
-  align-items: center;
-  display: grid;
-  grid-template-areas:
-    "primary title secondary";
-  grid-template-columns: 1fr auto 1fr;
-  grid-template-rows: 3rem;
-  justify-items: center;
-  min-height: 3.5rem;
-  padding: 0 1rem;
+    align-content: center;
+    align-items: center;
+    display: grid;
+    grid-template-areas: 'primary title secondary';
+    grid-template-columns: 1fr auto 1fr;
+    grid-template-rows: 3rem;
+    justify-items: center;
+    min-height: 3.5rem;
+    padding: 0 1rem;
 }
 
 .navTrigger,
 .cartTrigger,
 .searchTrigger {
-  composes: root from '../clickable.css';
-  height: 3rem;
-  width: 3rem;
+    composes: root from '../clickable.css';
+    height: 3rem;
+    width: 3rem;
 }
 
 .logo {
-  grid-area: title;
+    grid-area: title;
 }
 
 .primaryActions {
-  grid-area: primary;
-  justify-self: start;
+    grid-area: primary;
+    justify-self: start;
 }
 
 .secondaryActions {
-  grid-area: secondary;
-  justify-self: end;
+    grid-area: secondary;
+    justify-self: end;
 }
 
 .searchBlock {
-  align-items: center;
-  display: none;
-  flex: none;
-  justify-content: center;
-  order: 1;
-  padding: 0 0.5rem 1rem;
-  width: 100%;
+    align-items: center;
+    display: none;
+    flex: none;
+    justify-content: center;
+    order: 1;
+    padding: 0 0.5rem 1rem;
+    width: 100%;
 }
 
 .searchInput {
-  border: 1px solid rgb(var(--venia-border));
-  border-radius: 6px;
-  font-size: 1rem;
-  height: 3rem;
-  padding: 0 1.5rem;
-  width: 24rem;
-  -webkit-appearance: none;
+    border: 1px solid rgb(var(--venia-border));
+    border-radius: 6px;
+    font-size: 1rem;
+    height: 3rem;
+    padding: 0 1.5rem;
+    width: 24rem;
+    -webkit-appearance: none;
 }

--- a/packages/venia-concept/src/components/Header/navTrigger.css
+++ b/packages/venia-concept/src/components/Header/navTrigger.css
@@ -1,5 +1,5 @@
 .root {
-  composes: root from "../clickable.css";
-  height: 3rem;
-  width: 3rem;
+    composes: root from '../clickable.css';
+    height: 3rem;
+    width: 3rem;
 }

--- a/packages/venia-concept/src/components/Home/home.css
+++ b/packages/venia-concept/src/components/Home/home.css
@@ -1,103 +1,103 @@
 .Home-title {
-  display: none;
+    display: none;
 }
 
 .Home-hero {
-  background-color: rgb(var(--venia-grey));
-  color: white;
-  display: grid;
-  grid-template-columns: 1fr auto;
-  grid-template-rows: 12rem auto auto 1fr;
-  height: 440px;
-  justify-items: center;
-  padding: 1rem 1.5rem;
+    background-color: rgb(var(--venia-grey));
+    color: white;
+    display: grid;
+    grid-template-columns: 1fr auto;
+    grid-template-rows: 12rem auto auto 1fr;
+    height: 440px;
+    justify-items: center;
+    padding: 1rem 1.5rem;
 }
 
 .Home-hero-title {
-  color: white;
-  font-size: 1.5rem;
-  font-weight: 400;
-  margin: 0;
-  min-width: 13.5rem;
-  grid-column: 2 / 3;
-  grid-row: 2 / 3;
-  text-align: center;
-  text-shadow: 0 1px rgba(0, 0, 0, 0.1);
+    color: white;
+    font-size: 1.5rem;
+    font-weight: 400;
+    margin: 0;
+    min-width: 13.5rem;
+    grid-column: 2 / 3;
+    grid-row: 2 / 3;
+    text-align: center;
+    text-shadow: 0 1px rgba(0, 0, 0, 0.1);
 }
 
 .Home-hero-actions {
-  grid-column: 2 / 3;
-  grid-row: 3 / 4;
-  margin-top: 1.25rem;
+    grid-column: 2 / 3;
+    grid-row: 3 / 4;
+    margin-top: 1.25rem;
 }
 
 .Home-hero-actions-action {
-  align-items: center;
-  background-color: black;
-  border-radius: 1.5rem;
-  color: white;
-  display: inline-flex;
-  font-size: 1rem;
-  font-weight: 600;
-  height: 3rem;
-  justify-content: center;
-  line-height: 1;
-  padding: 0 1.25rem;
+    align-items: center;
+    background-color: black;
+    border-radius: 1.5rem;
+    color: white;
+    display: inline-flex;
+    font-size: 1rem;
+    font-weight: 600;
+    height: 3rem;
+    justify-content: center;
+    line-height: 1;
+    padding: 0 1.25rem;
 }
 
 .Home-saleBanner {
-  background-color: rgb(var(--venia-teal));
-  color: white;
-  padding: 0.5rem 3rem;
-  text-align: center;
+    background-color: rgb(var(--venia-teal));
+    color: white;
+    padding: 0.5rem 3rem;
+    text-align: center;
 }
 
 .Home-saleBanner-copy {
-  margin-bottom: 0.5rem;
-  margin-top: 0.5rem;
+    margin-bottom: 0.5rem;
+    margin-top: 0.5rem;
 }
 
 .Home-storySection-title {
-  font-size: 1.75rem;
-  font-weight: 400;
-  line-height: 1;
-  margin: 3.25rem 0 2.5rem;
-  text-align: center;
+    font-size: 1.75rem;
+    font-weight: 400;
+    line-height: 1;
+    margin: 3.25rem 0 2.5rem;
+    text-align: center;
 }
 
 .Home-storySection-image {
-  background-color: rgb(var(--venia-grey));
-  height: 360px;
+    background-color: rgb(var(--venia-grey));
+    height: 360px;
 }
 
 .Home-storySection-content {
-  background-color: white;
-  line-height: 1.75;
-  padding: 2.5rem;
-  text-align: center;
+    background-color: white;
+    line-height: 1.75;
+    padding: 2.5rem;
+    text-align: center;
 }
 
 .Home-storySection-content-copy:nth-of-type(1) {
-  font-size: 1.25rem;
-  font-weight: 300;
-  margin-bottom: 1.5rem;
-  margin-top: 0;
+    font-size: 1.25rem;
+    font-weight: 300;
+    margin-bottom: 1.5rem;
+    margin-top: 0;
 }
 
 .Home-storySection-content-actions {
-  margin-top: 2.5rem;
+    margin-top: 2.5rem;
 }
 
 .Home-storySection-content-actions-action {
-  align-items: center;
-  background-color: rgb(var(--venia-teal));
-  border-radius: 1.5rem;
-  color: white;
-  display: inline-flex;
-  font-size: 1rem;
-  font-weight: 600;
-  height: 3rem;
-  justify-content: center;
-  line-height: 1;
-  padding: 0 1.25rem;
+    align-items: center;
+    background-color: rgb(var(--venia-teal));
+    border-radius: 1.5rem;
+    color: white;
+    display: inline-flex;
+    font-size: 1rem;
+    font-weight: 600;
+    height: 3rem;
+    justify-content: center;
+    line-height: 1;
+    padding: 0 1.25rem;
 }

--- a/packages/venia-concept/src/components/Icon/icon.css
+++ b/packages/venia-concept/src/components/Icon/icon.css
@@ -1,5 +1,5 @@
 .root {
-  align-items: center;
-  display: inline-flex;
-  justify-content: center;
+    align-items: center;
+    display: inline-flex;
+    justify-content: center;
 }

--- a/packages/venia-concept/src/components/Main/main.css
+++ b/packages/venia-concept/src/components/Main/main.css
@@ -1,13 +1,13 @@
 .root {
-  background-color: white;
-  color: rgb(var(--venia-text));
-  position: relative;
-  z-index: 1;
+    background-color: white;
+    color: rgb(var(--venia-text));
+    position: relative;
+    z-index: 1;
 }
 
 /* state: masked */
 
 .root_masked {
-  composes: root;
-  filter: grayscale(1);
+    composes: root;
+    filter: grayscale(1);
 }

--- a/packages/venia-concept/src/components/MiniCart/miniCart.css
+++ b/packages/venia-concept/src/components/MiniCart/miniCart.css
@@ -1,84 +1,84 @@
 .root {
-  align-content: start;
-  background-color: white;
-  bottom: 0;
-  box-shadow: -1px 0 rgb(var(--venia-border));
-  display: grid;
-  grid-template-rows: min-content 1fr auto auto;
-  opacity: 0;
-  overflow: hidden;
-  position: fixed;
-  right: 0;
-  top: 0;
-  transform: translate3d(100%, 0, 0);
-  transition-duration: 192ms;
-  transition-property: opacity, transform, visibility;
-  transition-timing-function: cubic-bezier(0.4, 0, 1, 1);
-  visibility: hidden;
-  width: 360px;
-  z-index: 4;
+    align-content: start;
+    background-color: white;
+    bottom: 0;
+    box-shadow: -1px 0 rgb(var(--venia-border));
+    display: grid;
+    grid-template-rows: min-content 1fr auto auto;
+    opacity: 0;
+    overflow: hidden;
+    position: fixed;
+    right: 0;
+    top: 0;
+    transform: translate3d(100%, 0, 0);
+    transition-duration: 192ms;
+    transition-property: opacity, transform, visibility;
+    transition-timing-function: cubic-bezier(0.4, 0, 1, 1);
+    visibility: hidden;
+    width: 360px;
+    z-index: 4;
 }
 
 .header {
-  align-content: center;
-  align-items: center;
-  background-color: rgb(var(--venia-grey));
-  box-shadow: 0 1px rgb(var(--venia-border));
-  display: grid;
-  grid-auto-columns: auto;
-  grid-auto-flow: column;
-  grid-auto-rows: 3rem;
-  grid-template-columns: 1fr;
-  height: 3.5rem;
-  justify-content: end;
-  padding: 0 1rem;
-  position: relative;
-  z-index: 1;
+    align-content: center;
+    align-items: center;
+    background-color: rgb(var(--venia-grey));
+    box-shadow: 0 1px rgb(var(--venia-border));
+    display: grid;
+    grid-auto-columns: auto;
+    grid-auto-flow: column;
+    grid-auto-rows: 3rem;
+    grid-template-columns: 1fr;
+    height: 3.5rem;
+    justify-content: end;
+    padding: 0 1rem;
+    position: relative;
+    z-index: 1;
 }
 
 .title {
-  align-items: center;
-  display: inline-flex;
-  font-size: 1rem;
-  font-weight: 400;
-  margin-right: auto;
-  padding: 0;
-  text-transform: uppercase;
+    align-items: center;
+    display: inline-flex;
+    font-size: 1rem;
+    font-weight: 400;
+    margin-right: auto;
+    padding: 0;
+    text-transform: uppercase;
 }
 
 .body {
-  overflow: auto;
+    overflow: auto;
 }
 
 .footer {
-  box-shadow: 0 -1px rgb(var(--venia-border));
-  margin: 0 1.5rem;
-  padding: 1.5rem 0 0.5rem;
+    box-shadow: 0 -1px rgb(var(--venia-border));
+    margin: 0 1.5rem;
+    padding: 1.5rem 0 0.5rem;
 }
 
 .totals {
-  align-items: center;
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: center;
+    align-items: center;
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
 }
 
 .subtotalLabel {
-  color: rgb(var(--venia-text-alt));
+    color: rgb(var(--venia-text-alt));
 }
 
 .subtotalValue {
-  font-weight: 600;
-  margin-left: 0.5rem;
+    font-weight: 600;
+    margin-left: 0.5rem;
 }
 
 /* state: open */
 
 .root_open {
-  composes: root;
-  opacity: 1;
-  transform: translate3d(0, 0, 0);
-  transition-duration: 224ms;
-  transition-timing-function: cubic-bezier(0, 0, 0.2, 1);
-  visibility: visible;
+    composes: root;
+    opacity: 1;
+    transform: translate3d(0, 0, 0);
+    transition-duration: 224ms;
+    transition-timing-function: cubic-bezier(0, 0, 0.2, 1);
+    visibility: visible;
 }

--- a/packages/venia-concept/src/components/MiniCart/product.css
+++ b/packages/venia-concept/src/components/MiniCart/product.css
@@ -3,9 +3,9 @@
     display: grid;
     grid-gap: 0.375rem 1rem;
     grid-template-areas:
-        "image name"
-        "image options"
-        "image quantity";
+        'image name'
+        'image options'
+        'image quantity';
     grid-template-columns: 80px 1fr;
     grid-template-rows: min-content minmax(54px, 1fr) min-content;
 }

--- a/packages/venia-concept/src/components/MiniCart/productList.css
+++ b/packages/venia-concept/src/components/MiniCart/productList.css
@@ -1,6 +1,6 @@
 .root {
-  display: grid;
-  grid-gap: 1rem;
-  margin: 0 1.5rem;
-  padding: 1.5rem 0;
+    display: grid;
+    grid-gap: 1rem;
+    margin: 0 1.5rem;
+    padding: 1.5rem 0;
 }

--- a/packages/venia-concept/src/components/MiniCart/trigger.css
+++ b/packages/venia-concept/src/components/MiniCart/trigger.css
@@ -1,3 +1,3 @@
 .root {
-  composes: root from "../clickable.css";
+    composes: root from '../clickable.css';
 }

--- a/packages/venia-concept/src/components/Navigation/navigation.css
+++ b/packages/venia-concept/src/components/Navigation/navigation.css
@@ -1,96 +1,96 @@
 .root {
-  background-color: white;
-  bottom: 0;
-  display: grid;
-  grid-template-rows: auto 1fr auto;
-  left: 0;
-  position: fixed;
-  top: 0;
-  transition-property: opacity, transform, visibility;
-  width: 360px;
-  z-index: 3;
+    background-color: white;
+    bottom: 0;
+    display: grid;
+    grid-template-rows: auto 1fr auto;
+    left: 0;
+    position: fixed;
+    top: 0;
+    transition-property: opacity, transform, visibility;
+    width: 360px;
+    z-index: 3;
 }
 
 .header {
-  align-content: center;
-  align-items: center;
-  background-color: rgb(var(--venia-grey));
-  box-shadow: 0 1px rgb(var(--venia-border));
-  display: grid;
-  grid-auto-columns: auto;
-  grid-auto-flow: column;
-  grid-auto-rows: 3rem;
-  grid-template-columns: 1fr;
-  height: 3.5rem;
-  justify-content: end;
-  padding: 0 1rem;
-  position: relative;
+    align-content: center;
+    align-items: center;
+    background-color: rgb(var(--venia-grey));
+    box-shadow: 0 1px rgb(var(--venia-border));
+    display: grid;
+    grid-auto-columns: auto;
+    grid-auto-flow: column;
+    grid-auto-rows: 3rem;
+    grid-template-columns: 1fr;
+    height: 3.5rem;
+    justify-content: end;
+    padding: 0 1rem;
+    position: relative;
 }
 
 .title {
-  align-items: center;
-  display: inline-flex;
-  font-size: 1rem;
-  font-weight: 400;
-  margin: 0 auto 0 0;
-  padding: 0 1rem;
-  text-transform: uppercase;
+    align-items: center;
+    display: inline-flex;
+    font-size: 1rem;
+    font-weight: 400;
+    margin: 0 auto 0 0;
+    padding: 0 1rem;
+    text-transform: uppercase;
 }
 
 .navTrigger {
-  composes: root from '../clickable.css';
-  height: 3rem;
-  width: 3rem;
+    composes: root from '../clickable.css';
+    height: 3rem;
+    width: 3rem;
 }
 
 .tiles {
-  background-color: white;
-  display: grid;
-  grid-gap: 2rem;
-  grid-template-columns: repeat(3, 5rem);
-  justify-content: center;
-  padding: 2rem 0;
+    background-color: white;
+    display: grid;
+    grid-gap: 2rem;
+    grid-template-columns: repeat(3, 5rem);
+    justify-content: center;
+    padding: 2rem 0;
 }
 
 .items {
-  background-color: rgb(var(--venia-grey));
-  box-shadow: 0px -1px rgb(var(--venia-border));
-  display: grid;
-  grid-auto-columns: 3rem;
-  grid-auto-flow: column;
-  grid-auto-rows: 3rem;
-  grid-gap: 4rem;
-  justify-content: center;
-  list-style: none;
-  margin: 0;
-  padding: 0;
+    background-color: rgb(var(--venia-grey));
+    box-shadow: 0px -1px rgb(var(--venia-border));
+    display: grid;
+    grid-auto-columns: 3rem;
+    grid-auto-flow: column;
+    grid-auto-rows: 3rem;
+    grid-gap: 4rem;
+    justify-content: center;
+    list-style: none;
+    margin: 0;
+    padding: 0;
 }
 
 .item {
-  align-items: center;
-  display: inline-flex;
-  height: 3rem;
-  justify-content: center;
-  width: 3rem;
+    align-items: center;
+    display: inline-flex;
+    height: 3rem;
+    justify-content: center;
+    width: 3rem;
 }
 
 /* state: open,closed */
 
 .closed {
-  composes: root;
-  opacity: 0;
-  transform: translate3d(-100%, 0, 0);
-  transition-duration: 192ms;
-  transition-timing-function: cubic-bezier(0.4, 0, 1, 1);
-  visibility: hidden;
+    composes: root;
+    opacity: 0;
+    transform: translate3d(-100%, 0, 0);
+    transition-duration: 192ms;
+    transition-timing-function: cubic-bezier(0.4, 0, 1, 1);
+    visibility: hidden;
 }
 
 .open {
-  composes: root;
-  box-shadow: 1px 0 rgb(var(--venia-border));
-  opacity: 1;
-  transform: translate3d(0, 0, 0);
-  transition-duration: 224ms;
-  transition-timing-function: cubic-bezier(0, 0, 0.2, 1);
-  visibility: visible;
+    composes: root;
+    box-shadow: 1px 0 rgb(var(--venia-border));
+    opacity: 1;
+    transform: translate3d(0, 0, 0);
+    transition-duration: 224ms;
+    transition-timing-function: cubic-bezier(0, 0, 0.2, 1);
+    visibility: visible;
 }

--- a/packages/venia-concept/src/components/Navigation/tile.css
+++ b/packages/venia-concept/src/components/Navigation/tile.css
@@ -1,23 +1,23 @@
 .root {
-  display: block;
-  line-height: 1rem;
-  width: 5rem;
+    display: block;
+    line-height: 1rem;
+    width: 5rem;
 }
 
 .image {
-  background-image: linear-gradient(135deg, white, rgb(var(--venia-grey)));
-  border: 1px solid rgb(var(--venia-border));
-  border-radius: 50%;
-  display: block;
-  height: 5rem;
-  width: 5rem;
+    background-image: linear-gradient(135deg, white, rgb(var(--venia-grey)));
+    border: 1px solid rgb(var(--venia-border));
+    border-radius: 50%;
+    display: block;
+    height: 5rem;
+    width: 5rem;
 }
 
 .label {
-  align-items: center;
-  display: flex;
-  font-size: 0.8125rem;
-  margin: 0.5rem 0;
-  justify-content: center;
-  text-transform: capitalize;
+    align-items: center;
+    display: flex;
+    font-size: 0.8125rem;
+    margin: 0.5rem 0;
+    justify-content: center;
+    text-transform: capitalize;
 }

--- a/packages/venia-concept/src/components/Navigation/trigger.css
+++ b/packages/venia-concept/src/components/Navigation/trigger.css
@@ -1,3 +1,3 @@
 .root {
-  composes: root from "../clickable.css";
+    composes: root from '../clickable.css';
 }

--- a/packages/venia-concept/src/components/Page/mask.css
+++ b/packages/venia-concept/src/components/Page/mask.css
@@ -1,26 +1,26 @@
 .root {
-  background-color: black;
-  cursor: pointer;
-  display: block;
-  height: 100vh;
-  left: 0;
-  opacity: 0;
-  position: fixed;
-  top: 0;
-  transition-duration: 192ms;
-  transition-property: opacity, visibility;
-  transition-timing-function: linear;
-  visibility: hidden;
-  width: 100vw;
-  z-index: 2;
-  -webkit-appearance: none;
+    background-color: black;
+    cursor: pointer;
+    display: block;
+    height: 100vh;
+    left: 0;
+    opacity: 0;
+    position: fixed;
+    top: 0;
+    transition-duration: 192ms;
+    transition-property: opacity, visibility;
+    transition-timing-function: linear;
+    visibility: hidden;
+    width: 100vw;
+    z-index: 2;
+    -webkit-appearance: none;
 }
 
 /* state: active */
 
 .root_active {
-  composes: root;
-  opacity: 0.5;
-  transition-duration: 224ms;
-  visibility: visible;
+    composes: root;
+    opacity: 0.5;
+    transition-duration: 224ms;
+    visibility: visible;
 }

--- a/packages/venia-concept/src/components/Page/page.css
+++ b/packages/venia-concept/src/components/Page/page.css
@@ -1,11 +1,11 @@
 .root {
-  min-height: 100vh;
+    min-height: 100vh;
 }
 
 /* state: masked */
 
 .root_masked {
-  composes: root;
-  height: 100vh;
-  overflow: hidden;
+    composes: root;
+    height: 100vh;
+    overflow: hidden;
 }

--- a/packages/venia-concept/src/components/ProductImageCarousel/carousel.css
+++ b/packages/venia-concept/src/components/ProductImageCarousel/carousel.css
@@ -1,24 +1,24 @@
 .root {
-  display: grid;
-  grid-template-areas:
-    "main"
-    "thumbs";
-  grid-template-columns: auto;
-  grid-template-rows: auto;
+    display: grid;
+    grid-template-areas:
+        'main'
+        'thumbs';
+    grid-template-columns: auto;
+    grid-template-rows: auto;
 }
 
-@media(min-width: 1024px) {
-  .root {
-    grid-gap: 1.5rem;
-    grid-template-areas: "thumbs main";
-    grid-template-columns: 17fr 80fr;
-  }
+@media (min-width: 1024px) {
+    .root {
+        grid-gap: 1.5rem;
+        grid-template-areas: 'thumbs main';
+        grid-template-columns: 17fr 80fr;
+    }
 }
 
 .currentImage {
-  background-color: rgb(var(--venia-grey));
-  border-radius: 2px;
-  display: block;
-  grid-area: main;
-  width: 100%;
+    background-color: rgb(var(--venia-grey));
+    border-radius: 2px;
+    display: block;
+    grid-area: main;
+    width: 100%;
 }

--- a/packages/venia-concept/src/components/ProductImageCarousel/thumbnail.css
+++ b/packages/venia-concept/src/components/ProductImageCarousel/thumbnail.css
@@ -1,30 +1,30 @@
 .root {
-  border: 1px solid rgb(var(--venia-text));
-  border-radius: 50%;
-  height: 1rem;
-  width: 1rem;
+    border: 1px solid rgb(var(--venia-text));
+    border-radius: 50%;
+    height: 1rem;
+    width: 1rem;
 }
 
-@media(min-width:1024px) {
-  .root {
-    border: 0;
-    border-radius: 0;
-    height: auto;
-    width: auto;
-  }
+@media (min-width: 1024px) {
+    .root {
+        border: 0;
+        border-radius: 0;
+        height: auto;
+        width: auto;
+    }
 }
 
 .image {
-  display: none;
+    display: none;
 }
 
-@media(min-width: 1024px) {
-  .image {
-    background-color: rgb(var(--venia-grey));
-    border-radius: 2px;
-    box-shadow: 0 0 0 1px white;
-    display: block;
-    height: auto;
-    width: 100%;
-  }
+@media (min-width: 1024px) {
+    .image {
+        background-color: rgb(var(--venia-grey));
+        border-radius: 2px;
+        box-shadow: 0 0 0 1px white;
+        display: block;
+        height: auto;
+        width: 100%;
+    }
 }

--- a/packages/venia-concept/src/components/ProductImageCarousel/thumbnailList.css
+++ b/packages/venia-concept/src/components/ProductImageCarousel/thumbnailList.css
@@ -1,19 +1,19 @@
 .root {
-  align-content: stretch;
-  display: grid;
-  grid-auto-flow: column;
-  grid-gap: 1rem;
-  grid-template-columns: repeat(auto-fit, 1rem);
-  justify-content: center;
-  margin-top: -3rem;
+    align-content: stretch;
+    display: grid;
+    grid-auto-flow: column;
+    grid-gap: 1rem;
+    grid-template-columns: repeat(auto-fit, 1rem);
+    justify-content: center;
+    margin-top: -3rem;
 }
 
-@media(min-width: 1024px) {
-  .root {
-    align-content: start;
-    grid-auto-flow: row;
-    grid-gap: 1.5rem;
-    grid-template-columns: 1fr;
-    margin-top: 0;
-  }
+@media (min-width: 1024px) {
+    .root {
+        align-content: start;
+        grid-auto-flow: row;
+        grid-gap: 1.5rem;
+        grid-template-columns: 1fr;
+        margin-top: 0;
+    }
 }

--- a/packages/venia-concept/src/components/ProductOptions/option.css
+++ b/packages/venia-concept/src/components/ProductOptions/option.css
@@ -1,12 +1,12 @@
 .root {
-  border-bottom: 1px solid rgb(var(--venia-border));
-  margin: 0 1.5rem;
-  padding: 1.75rem 0;
+    border-bottom: 1px solid rgb(var(--venia-border));
+    margin: 0 1.5rem;
+    padding: 1.75rem 0;
 }
 
 .title {
-  font-size: 1rem;
-  font-weight: 600;
-  line-height: 1.5;
-  margin-bottom: 1.5rem;
+    font-size: 1rem;
+    font-weight: 600;
+    line-height: 1.5;
+    margin-bottom: 1.5rem;
 }

--- a/packages/venia-concept/src/components/ProductOptions/swatch.css
+++ b/packages/venia-concept/src/components/ProductOptions/swatch.css
@@ -1,5 +1,5 @@
 .root {
-  composes: root from "./tile.css";
-  background-color: rgb(var(--swatch-color));
-  border-color: rgba(0, 0, 0, 0.1);
+    composes: root from './tile.css';
+    background-color: rgb(var(--swatch-color));
+    border-color: rgba(0, 0, 0, 0.1);
 }

--- a/packages/venia-concept/src/components/ProductOptions/swatchList.css
+++ b/packages/venia-concept/src/components/ProductOptions/swatchList.css
@@ -1,3 +1,3 @@
 .root {
-  composes: root from "./tileList.css";
+    composes: root from './tileList.css';
 }

--- a/packages/venia-concept/src/components/ProductOptions/tile.css
+++ b/packages/venia-concept/src/components/ProductOptions/tile.css
@@ -1,23 +1,23 @@
 .root {
-  composes: root from "../clickable.css";
-  border: 1px solid rgb(var(--venia-text));
-  border-radius: 2px;
-  height: 3rem;
-  margin-left: 1rem;
-  margin-top: 1rem;
-  min-width: 3rem;
-  padding: 0 0.75rem;
+    composes: root from '../clickable.css';
+    border: 1px solid rgb(var(--venia-text));
+    border-radius: 2px;
+    height: 3rem;
+    margin-left: 1rem;
+    margin-top: 1rem;
+    min-width: 3rem;
+    padding: 0 0.75rem;
 }
 
-@media(min-width: 1024px) {
-  .root {
-    height: 2rem;
-    min-width: 2rem;
-    padding: 0;
-  }
+@media (min-width: 1024px) {
+    .root {
+        height: 2rem;
+        min-width: 2rem;
+        padding: 0;
+    }
 }
 
 .root_selected {
-  background-color: rgb(var(--venia-text));
-  color: white;
+    background-color: rgb(var(--venia-text));
+    color: white;
 }

--- a/packages/venia-concept/src/components/ProductOptions/tileList.css
+++ b/packages/venia-concept/src/components/ProductOptions/tileList.css
@@ -1,6 +1,6 @@
 .root {
-  display: flex;
-  flex-wrap: wrap;
-  margin-left: -1rem;
-  margin-top: -1rem;
+    display: flex;
+    flex-wrap: wrap;
+    margin-left: -1rem;
+    margin-top: -1rem;
 }

--- a/packages/venia-concept/src/components/ProductQuantity/quantity.css
+++ b/packages/venia-concept/src/components/ProductQuantity/quantity.css
@@ -1,14 +1,14 @@
 .root {
-  display: grid;
-  grid-gap: 1rem;
+    display: grid;
+    grid-gap: 1rem;
 }
 
 .inventory {
-  align-items: center;
-  background-color: rgb(var(--venia-grey));
-  display: inline-flex;
-  font-size: 0.875rem;
-  font-weight: 600;
-  line-height: 1rem;
-  padding: 0.75rem;
+    align-items: center;
+    background-color: rgb(var(--venia-grey));
+    display: inline-flex;
+    font-size: 0.875rem;
+    font-weight: 600;
+    line-height: 1rem;
+    padding: 0.75rem;
 }

--- a/packages/venia-concept/src/components/RichText/richText.css
+++ b/packages/venia-concept/src/components/RichText/richText.css
@@ -1,15 +1,15 @@
 .root {
-  font-size: 0.875rem;
-  line-height: 1.25rem;
-  padding: 0 0.5rem;
+    font-size: 0.875rem;
+    line-height: 1.25rem;
+    padding: 0 0.5rem;
 }
 
 .root p {
-  margin: 0 0 1rem;
+    margin: 0 0 1rem;
 }
 
 .root ul {
-  list-style-type: disc;
-  margin: 0 0 1rem;
-  padding-left: 2.5rem;
+    list-style-type: disc;
+    margin: 0 0 1rem;
+    padding-left: 2.5rem;
 }

--- a/packages/venia-concept/src/components/Select/select.css
+++ b/packages/venia-concept/src/components/Select/select.css
@@ -1,13 +1,13 @@
 .root {
-  align-items: center;
-  background: none;
-  border: 1px solid currentColor;
-  border-radius: 2px;
-  color: inherit;
-  display: flex;
-  font-size: 1rem;
-  height: 2.5rem;
-  padding-left: calc(0.75rem - 1px);
-  padding-right: calc(2.5rem - 1px);
-  -webkit-appearance: none;
+    align-items: center;
+    background: none;
+    border: 1px solid currentColor;
+    border-radius: 2px;
+    color: inherit;
+    display: flex;
+    font-size: 1rem;
+    height: 2.5rem;
+    padding-left: calc(0.75rem - 1px);
+    padding-right: calc(2.5rem - 1px);
+    -webkit-appearance: none;
 }

--- a/packages/venia-concept/src/components/clickable.css
+++ b/packages/venia-concept/src/components/clickable.css
@@ -1,10 +1,10 @@
 .root {
-  align-items: center;
-  cursor: pointer;
-  display: inline-flex;
-  justify-content: center;
-  line-height: 1;
-  padding: 0;
-  text-align: center;
-  white-space: nowrap;
+    align-items: center;
+    cursor: pointer;
+    display: inline-flex;
+    justify-content: center;
+    line-height: 1;
+    padding: 0;
+    text-align: center;
+    white-space: nowrap;
 }

--- a/packages/venia-concept/src/index.css
+++ b/packages/venia-concept/src/index.css
@@ -1,74 +1,82 @@
 * {
-  box-sizing: border-box;
+    box-sizing: border-box;
 }
 
 html {
-  --venia-border: 224, 224, 224;
-  --venia-font: Muli, -apple-system, BlinkMacSystemFont, sans-serif;
-  --venia-grey: 246, 246, 246;
-  --venia-teal: 0, 134, 138;
-  --venia-teal-alt: 224, 240, 241;
-  --venia-text: 33, 33, 33;
-  --venia-text-alt: 117, 117, 117;
-  --venia-text-hint: 158, 158, 158;
+    --venia-border: 224, 224, 224;
+    --venia-font: Muli, -apple-system, BlinkMacSystemFont, sans-serif;
+    --venia-grey: 246, 246, 246;
+    --venia-teal: 0, 134, 138;
+    --venia-teal-alt: 224, 240, 241;
+    --venia-text: 33, 33, 33;
+    --venia-text-alt: 117, 117, 117;
+    --venia-text-hint: 158, 158, 158;
 }
 
 html {
-  background-color: white;
-  font-family: var(--venia-font);
-  font-size: 100%;
-  font-weight: 400;
-  line-height: 1;
-  -moz-osx-font-smoothing: grayscale;
-  -webkit-font-smoothing: antialiased;
+    background-color: white;
+    font-family: var(--venia-font);
+    font-size: 100%;
+    font-weight: 400;
+    line-height: 1;
+    -moz-osx-font-smoothing: grayscale;
+    -webkit-font-smoothing: antialiased;
 }
 
 body {
-  background-color: white;
-  color: rgb(var(--venia-text));
-  margin: 0;
-  padding: 0;
+    background-color: white;
+    color: rgb(var(--venia-text));
+    margin: 0;
+    padding: 0;
 }
 
-h1, h2, h3, h4, h5, h6 {
-  font-size: 1rem;
-  font-weight: 400;
-  margin: 0;
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+    font-size: 1rem;
+    font-weight: 400;
+    margin: 0;
 }
 
 h1 {
-  font-size: 1.5rem;
+    font-size: 1.5rem;
 }
 
 h2 {
-  font-size: 1.25rem;
+    font-size: 1.25rem;
 }
 
 a {
-  color: currentColor;
-  text-decoration: none;
+    color: currentColor;
+    text-decoration: none;
 }
 
 p {
-  margin: 0;
+    margin: 0;
 }
 
-dl, ol, ul {
-  list-style-type: none;
-  margin: 0;
-  padding: 0;
+dl,
+ol,
+ul {
+    list-style-type: none;
+    margin: 0;
+    padding: 0;
 }
 
-dd, dt {
-  margin: 0;
+dd,
+dt {
+    margin: 0;
 }
 
 button {
-  background: none;
-  border: 0;
-  cursor: pointer;
-  font-family: var(--venia-font);
-  font-size: 100%;
-  padding: 0;
-  -webkit-appearance: none;
+    background: none;
+    border: 0;
+    cursor: pointer;
+    font-family: var(--venia-font);
+    font-size: 100%;
+    padding: 0;
+    -webkit-appearance: none;
 }


### PR DESCRIPTION
## This PR is a:

[ ] New feature
[x] Enhancement/Optimization
[ ] Refactor
[ ] Bugfix
[ ] Test for existing code
[ ] Documentation

## Summary

When this pull request is merged, Prettier will format CSS (in addition to JS, as it currently does).

## Additional information

Currently, CSS is neither linted nor formatted. As a result, our files have a mixture of two-space and four-space indentation, single quotes and double quotes, etc. Prettier is currently not formatting these files because we have explicitly instructed it to only format JS files. This PR changes that configuration to include CSS files as well.