### PR TITLE
Fixes after greenkeeper updates

### DIFF
--- a/packages/peregrine/jest.config.js
+++ b/packages/peregrine/jest.config.js
@@ -4,6 +4,8 @@ module.exports = {
         '<rootDir>/scripts/shim.js',
         '<rootDir>/scripts/fetch-mock.js'
     ],
+    browser: true,
+    testURL: 'https://localhost/',
     coveragePathIgnorePatterns: ['scripts/*', 'node_modules', 'src/index.js'],
     testPathIgnorePatterns: ['dist', 'node_modules']
 };

--- a/packages/peregrine/src/Price/__tests__/Price.spec.js
+++ b/packages/peregrine/src/Price/__tests__/Price.spec.js
@@ -8,6 +8,7 @@ configure({ adapter: new Adapter() });
 
 if (!global.Intl.NumberFormat.prototype.formatToParts) {
     global.Intl = IntlPolyfill;
+    require('intl/locale-data/jsonp/en.js');
 }
 
 test('Renders a USD price', () => {

--- a/packages/venia-concept/jest.config.js
+++ b/packages/venia-concept/jest.config.js
@@ -3,6 +3,7 @@ const { join } = require('path');
 module.exports = {
     displayName: 'Venia Concept',
     browser: true,
+    testURL: 'https://localhost/',
     moduleNameMapper: {
         '\\.css$': 'identity-obj-proxy',
         // Mirrors webpack alias to resolve from 'src'

--- a/packages/venia-concept/src/components/MiniCart/miniCart.js
+++ b/packages/venia-concept/src/components/MiniCart/miniCart.js
@@ -73,7 +73,10 @@ class MiniCart extends Component {
         return cartId && cart.totals && 'subtotal' in cart.totals ? (
             <dl className={classes.totals}>
                 <dt className={classes.subtotalLabel}>
-                    <span>Subtotal{` (${cart.details.items_qty} Items)`}</span>
+                    <span>
+                        Subtotal
+                        {` (${cart.details.items_qty} Items)`}
+                    </span>
                 </dt>
                 <dd className={classes.subtotalValue}>
                     <Price

--- a/packages/venia-concept/src/util/__tests__/getUrlKey.spec.js
+++ b/packages/venia-concept/src/util/__tests__/getUrlKey.spec.js
@@ -14,5 +14,6 @@ test('gets the last path segment', () => {
 });
 
 test('uses the window.location object if no argument', () => {
-    expect(getUrlKey()).toMatch(window.location.pathname);
+    // should match pathname except with no leading slash
+    expect(getUrlKey()).toMatch(window.location.pathname.replace(/^\//, ''));
 });


### PR DESCRIPTION
<!-- (REQUIRED) What is the nature of this PR? -->

## This PR is a:

[ ] New feature
[ ] Enhancement/Optimization
[ ] Refactor
[x] Bugfix
[ ] Test for existing code
[ ] Documentation

<!-- (REQUIRED) What does this PR change? -->

## Summary

When this pull request is merged, it will fix some linting and testing regressions from incoming dependency updates.

<!-- (OPTIONAL) What other information can you provide about this PR? -->

- Prettier output slightly changed
- Jest now requires a specific `testURL` to make `window.location` available
- JSDOM Intl now requires a language pack

## Additional information

We'll get better at processing these piles of Greenkeeper updates as they come in.

Also, I will be unilaterally merging this in order to enable folks checking out the repository today.