### PR TITLE
Update repository url in package.json files

### DIFF
--- a/packages/peregrine/package.json
+++ b/packages/peregrine/package.json
@@ -8,10 +8,11 @@
   "files": [
     "dist"
   ],
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/magento-research/peregrine"
+  "repository": "github:magento-research/pwa-studio",
+  "bugs": {
+    "url": "https://github.com/magento-research/pwa-studio/issues"
   },
+  "homepage": "https://github.com/magento-research/pwa-studio/tree/master/packages/peregrine#readme",
   "scripts": {
     "build": "babel src -d dist --ignore '*.test.js,*.spec.js'",
     "clean": "rimraf dist",

--- a/packages/pwa-buildpack/package.json
+++ b/packages/pwa-buildpack/package.json
@@ -15,10 +15,7 @@
   "engines": {
     "node": ">=8.0.0"
   },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/magento-research/pwa-buildpack.git"
-  },
+  "repository": "github:magento-research/pwa-studio",
   "keywords": [
     "magento",
     "pwa",
@@ -28,9 +25,9 @@
   "author": "Magento Commerce",
   "license": "SEE LICENSE IN LICENSE.txt",
   "bugs": {
-    "url": "https://github.com/magento-research/pwa-buildpack/issues"
+    "url": "https://github.com/magento-research/pwa-studio/issues"
   },
-  "homepage": "https://github.com/magento-research/pwa-buildpack#readme",
+  "homepage": "https://github.com/magento-research/pwa-studio/tree/master/packages/pwa-buildpack#readme",
   "devDependencies": {
     "babel-cli": "^6.26.0",
     "babel-core": "^6.26.0",

--- a/packages/pwa-devdocs/package.json
+++ b/packages/pwa-devdocs/package.json
@@ -19,14 +19,11 @@
     "test-links": "rm -fr _site && npm run build && node_modules/broken-link-checker-local/out/bin.js _site -rog",
     "tests": "npm run test-links"
   },
-  "repository": {
-    "type": "git",
-    "url": "git+git@github.com:magento-research/pwa-studio.git"
-  },
+  "repository": "github:magento-research/pwa-studio",
   "author": "James Calcaben",
   "license": "OSL-3.0",
   "bugs": {
     "url": "https://github.com/magento-research/pwa-studio/issues"
   },
-  "homepage": "https://github.com/magento-research/pwa-studio#readme"
+  "homepage": "https://github.com/magento-research/pwa-studio/tree/master/packages/pwa-devdocs#readme"
 }

--- a/packages/venia-concept/package.json
+++ b/packages/venia-concept/package.json
@@ -5,10 +5,11 @@
     "license": "(OSL-3.0 OR AFL-3.0)",
     "author": "Magento Commerce",
     "main": "src/index.js",
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/magento-research/venia-pwa-concept"
+    "repository": "github:magento-research/pwa-studio",
+    "bugs": {
+      "url": "https://github.com/magento-research/pwa-studio/issues"
     },
+    "homepage": "https://github.com/magento-research/pwa-studio/tree/master/packages/venia-concept#readme",
     "scripts": {
         "build": "webpack --progress --color --env.phase production",
         "prepare": "npm-merge-driver install",


### PR DESCRIPTION
After moving to monorepo urls to repositories and other stuff remains old, which is kinda confusing while you are trying to find the package source on npmjs.org