### PR TITLE
chore(deps): Refresh package-lock manually

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3729,27 +3729,27 @@
       "dependencies": {
         "abbrev": {
           "version": "1.1.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
           "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
           "dev": true,
           "optional": true
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
           "dev": true
         },
         "aproba": {
           "version": "1.2.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
           "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
           "dev": true,
           "optional": true
         },
         "are-we-there-yet": {
           "version": "1.1.4",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
           "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
           "dev": true,
           "optional": true,
@@ -3760,13 +3760,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
           "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
           "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
           "requires": {
@@ -3776,39 +3776,39 @@
         },
         "chownr": {
           "version": "1.0.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.0.1.tgz",
           "integrity": "sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE=",
           "dev": true,
           "optional": true
         },
         "code-point-at": {
           "version": "1.1.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
           "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
           "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
           "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
           "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
           "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
           "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
           "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
           "dev": true,
           "optional": true
         },
         "debug": {
           "version": "2.6.9",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
           "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "dev": true,
           "optional": true,
@@ -3818,28 +3818,28 @@
         },
         "deep-extend": {
           "version": "0.5.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.5.1.tgz",
           "integrity": "sha512-N8vBdOa+DF7zkRrDCsaOXoCs/E2fJfx9B9MrKnnSiHNh4ws7eSys6YQE4KvT1cecKmOASYQBhbKjeuDD9lT81w==",
           "dev": true,
           "optional": true
         },
         "delegates": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
           "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
           "dev": true,
           "optional": true
         },
         "detect-libc": {
           "version": "1.0.3",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
           "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
           "dev": true,
           "optional": true
         },
         "fs-minipass": {
           "version": "1.2.5",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.5.tgz",
           "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
           "dev": true,
           "optional": true,
@@ -3849,14 +3849,14 @@
         },
         "fs.realpath": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
           "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
           "dev": true,
           "optional": true
         },
         "gauge": {
           "version": "2.7.4",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
           "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
           "dev": true,
           "optional": true,
@@ -3873,7 +3873,7 @@
         },
         "glob": {
           "version": "7.1.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
           "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "optional": true,
@@ -3888,14 +3888,14 @@
         },
         "has-unicode": {
           "version": "2.0.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
           "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
           "dev": true,
           "optional": true
         },
         "iconv-lite": {
           "version": "0.4.21",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.21.tgz",
           "integrity": "sha512-En5V9za5mBt2oUA03WGD3TwDv0MKAruqsuxstbMUZaj9W9k/m1CV/9py3l0L5kw9Bln8fdHQmzHSYtvpvTLpKw==",
           "dev": true,
           "optional": true,
@@ -3905,7 +3905,7 @@
         },
         "ignore-walk": {
           "version": "3.0.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.1.tgz",
           "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
           "dev": true,
           "optional": true,
@@ -3915,7 +3915,7 @@
         },
         "inflight": {
           "version": "1.0.6",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
           "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
           "dev": true,
           "optional": true,
@@ -3926,20 +3926,20 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
           "dev": true
         },
         "ini": {
           "version": "1.3.5",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
           "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
           "dev": true,
           "optional": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
           "requires": {
@@ -3948,14 +3948,14 @@
         },
         "isarray": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
           "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
           "dev": true,
           "optional": true
         },
         "minimatch": {
           "version": "3.0.4",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
@@ -3964,13 +3964,13 @@
         },
         "minimist": {
           "version": "0.0.8",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
           "dev": true
         },
         "minipass": {
           "version": "2.2.4",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.2.4.tgz",
           "integrity": "sha512-hzXIWWet/BzWhYs2b+u7dRHlruXhwdgvlTMDKC6Cb1U7ps6Ac6yQlR39xsbjWJE377YTCtKwIXIpJ5oP+j5y8g==",
           "dev": true,
           "requires": {
@@ -3980,7 +3980,7 @@
         },
         "minizlib": {
           "version": "1.1.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.1.0.tgz",
           "integrity": "sha512-4T6Ur/GctZ27nHfpt9THOdRZNgyJ9FZchYO1ceg5S8Q3DNLCKYy44nCZzgCJgcvx2UM8czmqak5BCxJMrq37lA==",
           "dev": true,
           "optional": true,
@@ -3990,7 +3990,7 @@
         },
         "mkdirp": {
           "version": "0.5.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
           "requires": {
@@ -3999,14 +3999,14 @@
         },
         "ms": {
           "version": "2.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true,
           "optional": true
         },
         "needle": {
           "version": "2.2.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/needle/-/needle-2.2.0.tgz",
           "integrity": "sha512-eFagy6c+TYayorXw/qtAdSvaUpEbBsDwDyxYFgLZ0lTojfH7K+OdBqAF7TAFwDokJaGpubpSGG0wO3iC0XPi8w==",
           "dev": true,
           "optional": true,
@@ -4018,7 +4018,7 @@
         },
         "node-pre-gyp": {
           "version": "0.10.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.10.0.tgz",
           "integrity": "sha512-G7kEonQLRbcA/mOoFoxvlMrw6Q6dPf92+t/l0DFSMuSlDoWaI9JWIyPwK0jyE1bph//CUEL65/Fz1m2vJbmjQQ==",
           "dev": true,
           "optional": true,
@@ -4037,7 +4037,7 @@
         },
         "nopt": {
           "version": "4.0.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
           "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
           "dev": true,
           "optional": true,
@@ -4048,14 +4048,14 @@
         },
         "npm-bundled": {
           "version": "1.0.3",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.0.3.tgz",
           "integrity": "sha512-ByQ3oJ/5ETLyglU2+8dBObvhfWXX8dtPZDMePCahptliFX2iIuhyEszyFk401PZUNQH20vvdW5MLjJxkwU80Ow==",
           "dev": true,
           "optional": true
         },
         "npm-packlist": {
           "version": "1.1.10",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.1.10.tgz",
           "integrity": "sha512-AQC0Dyhzn4EiYEfIUjCdMl0JJ61I2ER9ukf/sLxJUcZHfo+VyEfz2rMJgLZSS1v30OxPQe1cN0LZA1xbcaVfWA==",
           "dev": true,
           "optional": true,
@@ -4066,7 +4066,7 @@
         },
         "npmlog": {
           "version": "4.1.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
           "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
           "dev": true,
           "optional": true,
@@ -4079,20 +4079,20 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
           "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
           "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
           "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
           "dev": true,
           "optional": true
         },
         "once": {
           "version": "1.4.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
           "requires": {
@@ -4101,21 +4101,21 @@
         },
         "os-homedir": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
           "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
           "dev": true,
           "optional": true
         },
         "os-tmpdir": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
           "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
           "dev": true,
           "optional": true
         },
         "osenv": {
           "version": "0.1.5",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
           "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
           "dev": true,
           "optional": true,
@@ -4126,21 +4126,21 @@
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
           "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
           "dev": true,
           "optional": true
         },
         "process-nextick-args": {
           "version": "2.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
           "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
           "dev": true,
           "optional": true
         },
         "rc": {
           "version": "1.2.7",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.7.tgz",
           "integrity": "sha512-LdLD8xD4zzLsAT5xyushXDNscEjB7+2ulnl8+r1pnESlYtlJtVSoCMBGr30eDRJ3+2Gq89jK9P9e4tCEH1+ywA==",
           "dev": true,
           "optional": true,
@@ -4153,7 +4153,7 @@
           "dependencies": {
             "minimist": {
               "version": "1.2.0",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
               "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
               "dev": true,
               "optional": true
@@ -4162,7 +4162,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "optional": true,
@@ -4178,7 +4178,7 @@
         },
         "rimraf": {
           "version": "2.6.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
           "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
           "dev": true,
           "optional": true,
@@ -4188,48 +4188,48 @@
         },
         "safe-buffer": {
           "version": "5.1.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
           "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
           "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
           "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
           "dev": true,
           "optional": true
         },
         "sax": {
           "version": "1.2.4",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
           "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
           "dev": true,
           "optional": true
         },
         "semver": {
           "version": "5.5.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
           "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
           "dev": true,
           "optional": true
         },
         "set-blocking": {
           "version": "2.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
           "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
           "dev": true,
           "optional": true
         },
         "signal-exit": {
           "version": "3.0.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
           "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
           "dev": true,
           "optional": true
         },
         "string-width": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
           "requires": {
@@ -4240,7 +4240,7 @@
         },
         "string_decoder": {
           "version": "1.1.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "dev": true,
           "optional": true,
@@ -4250,7 +4250,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
@@ -4259,14 +4259,14 @@
         },
         "strip-json-comments": {
           "version": "2.0.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
           "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
           "dev": true,
           "optional": true
         },
         "tar": {
           "version": "4.4.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.1.tgz",
           "integrity": "sha512-O+v1r9yN4tOsvl90p5HAP4AEqbYhx4036AGMm075fH9F8Qwi3oJ+v4u50FkT/KkvywNGtwkk0zRI+8eYm1X/xg==",
           "dev": true,
           "optional": true,
@@ -4282,14 +4282,14 @@
         },
         "util-deprecate": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
           "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
           "dev": true,
           "optional": true
         },
         "wide-align": {
           "version": "1.1.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
           "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
           "dev": true,
           "optional": true,
@@ -4299,13 +4299,13 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
           "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
           "dev": true
         },
         "yallist": {
           "version": "3.0.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.2.tgz",
           "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k=",
           "dev": true
         }

--- a/packages/pwa-buildpack/package-lock.json
+++ b/packages/pwa-buildpack/package-lock.json
@@ -2993,9 +2993,9 @@
       "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
     },
     "fbjs": {
-      "version": "0.8.16",
-      "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.16.tgz",
-      "integrity": "sha1-XmdDL1UNxBtXK/VYR7ispk5TN9s=",
+      "version": "0.8.17",
+      "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.17.tgz",
+      "integrity": "sha1-xNWY6taUkRJlPWWIsBpc3Nn5D90=",
       "dev": true,
       "requires": {
         "core-js": "^1.0.0",
@@ -3004,7 +3004,7 @@
         "object-assign": "^4.1.0",
         "promise": "^7.1.1",
         "setimmediate": "^1.0.5",
-        "ua-parser-js": "^0.7.9"
+        "ua-parser-js": "^0.7.18"
       },
       "dependencies": {
         "core-js": {
@@ -5461,12 +5461,11 @@
       }
     },
     "prop-types": {
-      "version": "15.6.1",
-      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.1.tgz",
-      "integrity": "sha512-4ec7bY1Y66LymSUOH/zARVYObB23AT2h8cf6e/O6ZALB/N0sqZFEx7rq6EYPX2MkOdKORuooI/H5k9TlR4q7kQ==",
+      "version": "15.6.2",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.2.tgz",
+      "integrity": "sha512-3pboPvLiWD7dkI3qf3KbUe6hKFKa52w+AE0VCqECtf+QHAKgOL37tTaNCnuX1nAAQ4ZhyP+kYVKf8rLmJ/feDQ==",
       "dev": true,
       "requires": {
-        "fbjs": "^0.8.16",
         "loose-envify": "^1.3.1",
         "object-assign": "^4.1.1"
       }
@@ -5621,9 +5620,9 @@
       }
     },
     "react": {
-      "version": "16.4.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-16.4.0.tgz",
-      "integrity": "sha512-K0UrkLXSAekf5nJu89obKUM7o2vc6MMN9LYoKnCa+c+8MJRAT120xzPLENcWSRc7GYKIg0LlgJRDorrufdglQQ==",
+      "version": "16.4.2",
+      "resolved": "https://registry.npmjs.org/react/-/react-16.4.2.tgz",
+      "integrity": "sha512-dMv7YrbxO4y2aqnvA7f/ik9ibeLSHQJTI6TrYAenPSaQ6OXfb+Oti+oJiy8WBxgRzlKatYqtCjphTgDSCEiWFg==",
       "dev": true,
       "requires": {
         "fbjs": "^0.8.16",

--- a/packages/pwa-devdocs/package-lock.json
+++ b/packages/pwa-devdocs/package-lock.json
@@ -5,9 +5,9 @@
 	"requires": true,
 	"dependencies": {
 		"@types/node": {
-			"version": "10.3.4",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-10.3.4.tgz",
-			"integrity": "sha512-YMLlzdeNnAyLrQew39IFRkMacAR5BqKGIEei9ZjdHsIZtv+ZWKYTu1i7QJhetxQ9ReXx8w5f+cixdHZG3zgMQA=="
+			"version": "10.7.1",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-10.7.1.tgz",
+			"integrity": "sha512-EGoI4ylB/lPOaqXqtzAyL8HcgOuCtH2hkEaLmkueOYufsTFWBn4VCvlCDC2HW8Q+9iF+QVC3sxjDKQYjHQeZ9w=="
 		},
 		"abbrev": {
 			"version": "1.1.1",
@@ -289,9 +289,12 @@
 			"integrity": "sha512-wGUIVQXuehL5TCqQun8OW81jGzAWycqzFF8lFp+GOM5BXLYj3bKNsYC4daB7n6XjCqxQA/qgTJ+8ANR3acjrog=="
 		},
 		"asn1": {
-			"version": "0.2.3",
-			"resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
-			"integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
+			"version": "0.2.4",
+			"resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
+			"integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+			"requires": {
+				"safer-buffer": "~2.1.0"
+			}
 		},
 		"asn1.js": {
 			"version": "4.10.1",
@@ -327,9 +330,9 @@
 			}
 		},
 		"assert-plus": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
-			"integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ="
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+			"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
 		},
 		"assign-symbols": {
 			"version": "1.0.0",
@@ -385,14 +388,14 @@
 			}
 		},
 		"aws-sign2": {
-			"version": "0.6.0",
-			"resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
-			"integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8="
+			"version": "0.7.0",
+			"resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+			"integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
 		},
 		"aws4": {
-			"version": "1.7.0",
-			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.7.0.tgz",
-			"integrity": "sha512-32NDda82rhwD9/JBCCkB+MRYDp0oSvlo2IL6rQWA10PQi7tDUM3eqMSltXmY+Oyl/7N3P3qNtAlv7X0d9bI28w=="
+			"version": "1.8.0",
+			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
+			"integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
 		},
 		"axios": {
 			"version": "0.17.1",
@@ -1077,14 +1080,14 @@
 			"integrity": "sha1-R2iMuZu2gE8OBtPnY7HDLlfY5rY="
 		},
 		"batch": {
-			"version": "0.5.3",
-			"resolved": "https://registry.npmjs.org/batch/-/batch-0.5.3.tgz",
-			"integrity": "sha1-PzQU84AyF0O/wQQvmoP/HVgk1GQ="
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
+			"integrity": "sha1-3DQxT05nkxgJP8dgJyUl+UvyXBY="
 		},
 		"bcrypt-pbkdf": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
-			"integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+			"integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
 			"optional": true,
 			"requires": {
 				"tweetnacl": "^0.14.3"
@@ -1125,9 +1128,9 @@
 			},
 			"dependencies": {
 				"extend": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/extend/-/extend-2.0.1.tgz",
-					"integrity": "sha1-HugBBonnOV/5RIJByYZSvHWagmA="
+					"version": "2.0.2",
+					"resolved": "https://registry.npmjs.org/extend/-/extend-2.0.2.tgz",
+					"integrity": "sha512-AgFD4VU+lVLP6vjnlNfF7OeInLTyeyckCNPEsuxz1vi786UuK/nk6ynPuhn/h+Ju9++TQyr5EpLRI14fc1QtTQ=="
 				}
 			}
 		},
@@ -1179,14 +1182,6 @@
 				"qs": "6.5.1",
 				"raw-body": "2.3.2",
 				"type-is": "~1.6.15"
-			}
-		},
-		"boom": {
-			"version": "2.10.1",
-			"resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-			"integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
-			"requires": {
-				"hoek": "2.x.x"
 			}
 		},
 		"brace-expansion": {
@@ -1255,9 +1250,9 @@
 			}
 		},
 		"broken-link-checker-local": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/broken-link-checker-local/-/broken-link-checker-local-0.1.2.tgz",
-			"integrity": "sha512-U6SgU7C6nYZzgnLYkH3CSet8X1jWwBaGF/j3BBemeDpKH5b9Wyq/3pvDq2UuP/mFe4/T2P5bisbuHRSwu+IcHg==",
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/broken-link-checker-local/-/broken-link-checker-local-0.2.0.tgz",
+			"integrity": "sha512-zZNOyEEdwQ7Z3xPeB8wUZCURKphV0icsITq0ZlPxPI7M9ELD6gRIpVedzVq6XnPkbKALVkLjxhC3iZ+k3pAshA==",
 			"requires": {
 				"broken-link-checker": "^0.7.4",
 				"chalk": "^1.1.3",
@@ -1272,14 +1267,14 @@
 			"integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8="
 		},
 		"browser-sync": {
-			"version": "2.24.4",
-			"resolved": "https://registry.npmjs.org/browser-sync/-/browser-sync-2.24.4.tgz",
-			"integrity": "sha512-qfXv8vQA/Dctub2v44v/vPuvfC4XNd6bn+W5vWZVuhuy6w91lPsdY6qhalT2s2PjnJ3FR6kWq5wkTQgN26eKzA==",
+			"version": "2.24.6",
+			"resolved": "https://registry.npmjs.org/browser-sync/-/browser-sync-2.24.6.tgz",
+			"integrity": "sha512-3cVW8Ft3sPQ1t9gqZXBDZhTyRce8NW4wf5KzpCYcg6fWjPbyt+vZLvEo+sTq7c7eNQhi8lInQWbjIFEpoM2f7Q==",
 			"requires": {
 				"browser-sync-ui": "v1.0.1",
 				"bs-recipes": "1.3.4",
 				"chokidar": "1.7.0",
-				"connect": "3.5.0",
+				"connect": "3.6.6",
 				"connect-history-api-fallback": "^1.5.0",
 				"dev-ip": "^1.0.1",
 				"easy-extender": "2.3.2",
@@ -1297,10 +1292,10 @@
 				"raw-body": "^2.3.2",
 				"resp-modifier": "6.0.2",
 				"rx": "4.1.0",
-				"serve-index": "1.8.0",
+				"serve-index": "1.9.1",
 				"serve-static": "1.13.2",
 				"server-destroy": "1.0.1",
-				"socket.io": "2.0.4",
+				"socket.io": "2.1.1",
 				"ua-parser-js": "0.7.17",
 				"yargs": "6.4.0"
 			},
@@ -1520,9 +1515,9 @@
 			}
 		},
 		"buffer-from": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.0.tgz",
-			"integrity": "sha512-c5mRlguI/Pe2dSZmpER62rSCu0ryKmWddzRYsuXc50U2/g8jMOulc31VZMa4mYx31U5xsmSOpDCgH88Vl9cDGQ=="
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+			"integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
 		},
 		"buffer-xor": {
 			"version": "1.0.3",
@@ -1621,9 +1616,9 @@
 			"integrity": "sha1-++u5mr4VpWVPx3R+u1MVvf3jNY8="
 		},
 		"caseless": {
-			"version": "0.11.0",
-			"resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
-			"integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c="
+			"version": "0.12.0",
+			"resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+			"integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
 		},
 		"center-align": {
 			"version": "0.1.3",
@@ -1891,50 +1886,34 @@
 			"integrity": "sha1-g3bZjvAo5sss0kaOKM5CxcZasak="
 		},
 		"connect": {
-			"version": "3.5.0",
-			"resolved": "https://registry.npmjs.org/connect/-/connect-3.5.0.tgz",
-			"integrity": "sha1-s1dSWgtMH1BZnNmD4dnv7qlncZg=",
+			"version": "3.6.6",
+			"resolved": "https://registry.npmjs.org/connect/-/connect-3.6.6.tgz",
+			"integrity": "sha1-Ce/2xVr3I24TcTWnJXSFi2eG9SQ=",
 			"requires": {
-				"debug": "~2.2.0",
-				"finalhandler": "0.5.0",
-				"parseurl": "~1.3.1",
-				"utils-merge": "1.0.0"
+				"debug": "2.6.9",
+				"finalhandler": "1.1.0",
+				"parseurl": "~1.3.2",
+				"utils-merge": "1.0.1"
 			},
 			"dependencies": {
-				"debug": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-					"integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
-					"requires": {
-						"ms": "0.7.1"
-					}
-				},
 				"finalhandler": {
-					"version": "0.5.0",
-					"resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.5.0.tgz",
-					"integrity": "sha1-6VCKvs6bbbqHGmlCodeRG5GRGsc=",
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.0.tgz",
+					"integrity": "sha1-zgtoVbRYU+eRsvzGgARtiCU91/U=",
 					"requires": {
-						"debug": "~2.2.0",
+						"debug": "2.6.9",
+						"encodeurl": "~1.0.1",
 						"escape-html": "~1.0.3",
 						"on-finished": "~2.3.0",
-						"statuses": "~1.3.0",
+						"parseurl": "~1.3.2",
+						"statuses": "~1.3.1",
 						"unpipe": "~1.0.0"
 					}
-				},
-				"ms": {
-					"version": "0.7.1",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-					"integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg="
 				},
 				"statuses": {
 					"version": "1.3.1",
 					"resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
 					"integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4="
-				},
-				"utils-merge": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz",
-					"integrity": "sha1-ApT7kiu5N1FTVBxPcJYjHyh8ivg="
 				}
 			}
 		},
@@ -2065,14 +2044,6 @@
 				"which": "^1.2.9"
 			}
 		},
-		"cryptiles": {
-			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-			"integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
-			"requires": {
-				"boom": "2.x.x"
-			}
-		},
 		"crypto-browserify": {
 			"version": "3.12.0",
 			"resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.0.tgz",
@@ -2165,13 +2136,6 @@
 			"integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
 			"requires": {
 				"assert-plus": "^1.0.0"
-			},
-			"dependencies": {
-				"assert-plus": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-					"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
-				}
 			}
 		},
 		"date-now": {
@@ -2392,12 +2356,13 @@
 			}
 		},
 		"ecc-jsbn": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
-			"integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+			"integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
 			"optional": true,
 			"requires": {
-				"jsbn": "~0.1.0"
+				"jsbn": "~0.1.0",
+				"safer-buffer": "^2.1.0"
 			}
 		},
 		"ee-first": {
@@ -2443,16 +2408,15 @@
 			}
 		},
 		"engine.io": {
-			"version": "3.1.5",
-			"resolved": "https://registry.npmjs.org/engine.io/-/engine.io-3.1.5.tgz",
-			"integrity": "sha512-D06ivJkYxyRrcEe0bTpNnBQNgP9d3xog+qZlLbui8EsMr/DouQpf5o9FzJnWYHEYE0YsFHllUv2R1dkgYZXHcA==",
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/engine.io/-/engine.io-3.2.0.tgz",
+			"integrity": "sha512-mRbgmAtQ4GAlKwuPnnAvXXwdPhEx+jkc0OBCLrXuD/CRvwNK3AxRSnqK4FSqmAMRRHryVJP8TopOvmEaA64fKw==",
 			"requires": {
 				"accepts": "~1.3.4",
 				"base64id": "1.0.0",
 				"cookie": "0.3.1",
 				"debug": "~3.1.0",
 				"engine.io-parser": "~2.1.0",
-				"uws": "~9.14.0",
 				"ws": "~3.3.1"
 			},
 			"dependencies": {
@@ -2822,6 +2786,16 @@
 				"time-stamp": "^1.0.0"
 			}
 		},
+		"fast-deep-equal": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+			"integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ="
+		},
+		"fast-json-stable-stringify": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+			"integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
+		},
 		"filename-regex": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
@@ -2925,9 +2899,9 @@
 			"integrity": "sha1-2uRqnXj74lKSJYzB54CkHZXAN4I="
 		},
 		"follow-redirects": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.0.tgz",
-			"integrity": "sha512-fdrt472/9qQ6Kgjvb935ig6vJCuofpBUD14f9Vb+SLlm7xIe4Qva5gey8EKtv8lp7ahE1wilg3xL1znpVGtZIA==",
+			"version": "1.5.5",
+			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.5.tgz",
+			"integrity": "sha512-GHjtHDlY/ehslqv0Gr5N0PUJppgg/q0rOBvX0na1s7y1A3LWxPqCYU76s3Z1bM4+UZB4QF0usaXLT5wFpof5PA==",
 			"requires": {
 				"debug": "^3.1.0"
 			},
@@ -2961,12 +2935,12 @@
 			"integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
 		},
 		"form-data": {
-			"version": "2.1.4",
-			"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
-			"integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
+			"integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
 			"requires": {
 				"asynckit": "^0.4.0",
-				"combined-stream": "^1.0.5",
+				"combined-stream": "1.0.6",
 				"mime-types": "^2.1.12"
 			}
 		},
@@ -3529,19 +3503,6 @@
 				"globule": "~0.1.0"
 			}
 		},
-		"generate-function": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
-			"integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ="
-		},
-		"generate-object-property": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
-			"integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
-			"requires": {
-				"is-property": "^1.0.0"
-			}
-		},
 		"get-caller-file": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
@@ -3571,13 +3532,6 @@
 			"integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
 			"requires": {
 				"assert-plus": "^1.0.0"
-			},
-			"dependencies": {
-				"assert-plus": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-					"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
-				}
 			}
 		},
 		"glob": {
@@ -3589,6 +3543,16 @@
 				"inherits": "2",
 				"minimatch": "^2.0.1",
 				"once": "^1.3.0"
+			},
+			"dependencies": {
+				"minimatch": {
+					"version": "2.0.10",
+					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+					"integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
+					"requires": {
+						"brace-expansion": "^1.0.0"
+					}
+				}
 			}
 		},
 		"glob-base": {
@@ -3655,6 +3619,14 @@
 					"version": "0.0.1",
 					"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
 					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+				},
+				"minimatch": {
+					"version": "2.0.10",
+					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+					"integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
+					"requires": {
+						"brace-expansion": "^1.0.0"
+					}
 				},
 				"readable-stream": {
 					"version": "1.0.34",
@@ -3915,15 +3887,31 @@
 				"glogg": "^1.0.0"
 			}
 		},
+		"har-schema": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+			"integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
+		},
 		"har-validator": {
-			"version": "2.0.6",
-			"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
-			"integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
+			"version": "5.0.3",
+			"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
+			"integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
 			"requires": {
-				"chalk": "^1.1.1",
-				"commander": "^2.9.0",
-				"is-my-json-valid": "^2.12.4",
-				"pinkie-promise": "^2.0.0"
+				"ajv": "^5.1.0",
+				"har-schema": "^2.0.0"
+			},
+			"dependencies": {
+				"ajv": {
+					"version": "5.5.2",
+					"resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+					"integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+					"requires": {
+						"co": "^4.6.0",
+						"fast-deep-equal": "^1.0.0",
+						"fast-json-stable-stringify": "^2.0.0",
+						"json-schema-traverse": "^0.3.0"
+					}
+				}
 			}
 		},
 		"has": {
@@ -4027,17 +4015,6 @@
 				"minimalistic-assert": "^1.0.0"
 			}
 		},
-		"hawk": {
-			"version": "3.1.3",
-			"resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
-			"integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
-			"requires": {
-				"boom": "2.x.x",
-				"cryptiles": "2.x.x",
-				"hoek": "2.x.x",
-				"sntp": "1.x.x"
-			}
-		},
 		"hmac-drbg": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
@@ -4047,11 +4024,6 @@
 				"minimalistic-assert": "^1.0.0",
 				"minimalistic-crypto-utils": "^1.0.1"
 			}
-		},
-		"hoek": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-			"integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
 		},
 		"home-or-tmp": {
 			"version": "2.0.0",
@@ -4106,11 +4078,11 @@
 			}
 		},
 		"http-signature": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
-			"integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+			"integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
 			"requires": {
-				"assert-plus": "^0.2.0",
+				"assert-plus": "^1.0.0",
 				"jsprim": "^1.2.2",
 				"sshpk": "^1.7.0"
 			}
@@ -4121,9 +4093,9 @@
 			"integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM="
 		},
 		"humanize-duration": {
-			"version": "3.15.0",
-			"resolved": "https://registry.npmjs.org/humanize-duration/-/humanize-duration-3.15.0.tgz",
-			"integrity": "sha512-FTR8w/wZhj4AJkao99vMqCMRwE1j7q0JI+JjQBe6C26LRgg9JLgmXbr9VvBYi3/wx8WVC2ge+eNJ/ZG5nM5whg=="
+			"version": "3.15.1",
+			"resolved": "https://registry.npmjs.org/humanize-duration/-/humanize-duration-3.15.1.tgz",
+			"integrity": "sha512-xfwsDoAinTTTNUAuYUGdeSPOUWEXzn9Xkep5LR0gpSw0gMKfpqLA7oxLWVRstYtZUarnCaeN0QqkOTC0TTPUpg=="
 		},
 		"iconv-lite": {
 			"version": "0.4.19",
@@ -4201,9 +4173,9 @@
 			"integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
 		},
 		"ipaddr.js": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.6.0.tgz",
-			"integrity": "sha1-4/o1e3c9phnybpXwSdBVxyeW+Gs="
+			"version": "1.8.0",
+			"resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.8.0.tgz",
+			"integrity": "sha1-6qM9bd16zo9/b+DJygRA5wZzix4="
 		},
 		"is-absolute": {
 			"version": "1.0.0",
@@ -4355,30 +4327,6 @@
 				"is-extglob": "^2.1.0"
 			}
 		},
-		"is-my-ip-valid": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/is-my-ip-valid/-/is-my-ip-valid-1.0.0.tgz",
-			"integrity": "sha512-gmh/eWXROncUzRnIa1Ubrt5b8ep/MGSnfAUI3aRp+sqTCs1tv1Isl8d8F6JmkN3dXKc3ehZMrtiPN9eL03NuaQ=="
-		},
-		"is-my-json-valid": {
-			"version": "2.17.2",
-			"resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.17.2.tgz",
-			"integrity": "sha512-IBhBslgngMQN8DDSppmgDv7RNrlFotuuDsKcrCP3+HbFaVivIBU7u9oiiErw8sH4ynx3+gOGQ3q2otkgiSi6kg==",
-			"requires": {
-				"generate-function": "^2.0.0",
-				"generate-object-property": "^1.1.0",
-				"is-my-ip-valid": "^1.0.0",
-				"jsonpointer": "^4.0.0",
-				"xtend": "^4.0.0"
-			},
-			"dependencies": {
-				"xtend": {
-					"version": "4.0.1",
-					"resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-					"integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
-				}
-			}
-		},
 		"is-number": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
@@ -4447,11 +4395,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
 			"integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU="
-		},
-		"is-property": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
-			"integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ="
 		},
 		"is-relative": {
 			"version": "1.0.0",
@@ -4596,6 +4539,11 @@
 			"resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
 			"integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
 		},
+		"json-schema-traverse": {
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+			"integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
+		},
 		"json-stable-stringify": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
@@ -4627,11 +4575,6 @@
 			"resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
 			"integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
 		},
-		"jsonpointer": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
-			"integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk="
-		},
 		"jsprim": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
@@ -4641,13 +4584,6 @@
 				"extsprintf": "1.3.0",
 				"json-schema": "0.2.3",
 				"verror": "1.10.0"
-			},
-			"dependencies": {
-				"assert-plus": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-					"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
-				}
 			}
 		},
 		"kind-of": {
@@ -5119,11 +5055,11 @@
 			"integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo="
 		},
 		"minimatch": {
-			"version": "2.0.10",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
-			"integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
 			"requires": {
-				"brace-expansion": "^1.0.0"
+				"brace-expansion": "^1.1.7"
 			}
 		},
 		"minimist": {
@@ -5218,9 +5154,9 @@
 			"integrity": "sha512-3KL3fvuRkZ7s4IFOMfztb7zJp3QaVWnBeGoJlgB38XnCRPj/0tLzzLG5IB8NYOHbJ8g8UGrgZv44GLDk6CxTxA=="
 		},
 		"node-gyp": {
-			"version": "3.7.0",
-			"resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.7.0.tgz",
-			"integrity": "sha512-qDQE/Ft9xXP6zphwx4sD0t+VhwV7yFaloMpfbL2QnnDZcyaiakWlLdtFGGQfTAwpFHdpbRhRxVhIHN1OKAjgbg==",
+			"version": "3.8.0",
+			"resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.8.0.tgz",
+			"integrity": "sha512-3g8lYefrRRzvGeSowdJKAKyks8oUpLEd/DyPV4eMhVlhJ0aNaZqIrNUIPuEWWTAoPqyFkfGrM67MC69baqn6vA==",
 			"requires": {
 				"fstream": "^1.0.0",
 				"glob": "^7.0.3",
@@ -5229,7 +5165,7 @@
 				"nopt": "2 || 3",
 				"npmlog": "0 || 1 || 2 || 3 || 4",
 				"osenv": "0",
-				"request": ">=2.9.0 <2.82.0",
+				"request": "^2.87.0",
 				"rimraf": "2",
 				"semver": "~5.3.0",
 				"tar": "^2.0.0",
@@ -5295,9 +5231,9 @@
 			}
 		},
 		"node-sass": {
-			"version": "4.9.0",
-			"resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.9.0.tgz",
-			"integrity": "sha512-QFHfrZl6lqRU3csypwviz2XLgGNOoWQbo2GOvtsfQqOfL4cy1BtWnhx/XUeAO9LT3ahBzSRXcEO6DdvAH9DzSg==",
+			"version": "4.9.3",
+			"resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.9.3.tgz",
+			"integrity": "sha512-XzXyGjO+84wxyH7fV6IwBOTrEBe2f0a6SBze9QWWYR/cL74AcQUks2AsqcCZenl/Fp/JVbuEaLpgrLtocwBUww==",
 			"requires": {
 				"async-foreach": "^0.1.3",
 				"chalk": "^1.1.1",
@@ -5312,9 +5248,9 @@
 				"meow": "^3.7.0",
 				"mkdirp": "^0.5.1",
 				"nan": "^2.10.0",
-				"node-gyp": "^3.3.1",
+				"node-gyp": "^3.8.0",
 				"npmlog": "^4.0.0",
-				"request": "~2.79.0",
+				"request": "2.87.0",
 				"sass-graph": "^2.2.4",
 				"stdout-stream": "^1.4.0",
 				"true-case-path": "^1.0.2"
@@ -5895,6 +5831,11 @@
 				"sha.js": "^2.4.8"
 			}
 		},
+		"performance-now": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+			"integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
+		},
 		"pify": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
@@ -6327,12 +6268,12 @@
 			"integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
 		},
 		"proxy-addr": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.3.tgz",
-			"integrity": "sha512-jQTChiCJteusULxjBp8+jftSQE5Obdl3k4cnmLA6WXtK6XFuWRnvVL7aCiBqaLPM8c4ph0S4tKna8XvmIwEnXQ==",
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.4.tgz",
+			"integrity": "sha512-5erio2h9jp5CHGwcybmxmVqHmnCBZeewlfJ0pex+UW7Qny7OOZXTtH56TGNyBizkgiOwhJtMKrVzDTeKcySZwA==",
 			"requires": {
 				"forwarded": "~0.1.2",
-				"ipaddr.js": "1.6.0"
+				"ipaddr.js": "1.8.0"
 			}
 		},
 		"prr": {
@@ -6346,9 +6287,9 @@
 			"integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
 		},
 		"psl": {
-			"version": "1.1.28",
-			"resolved": "https://registry.npmjs.org/psl/-/psl-1.1.28.tgz",
-			"integrity": "sha512-+AqO1Ae+N/4r7Rvchrdm432afjT9hqJRyBN3DQv9At0tPz4hIFSGKbq64fN9dVoCow4oggIIax5/iONx0r9hZw=="
+			"version": "1.1.29",
+			"resolved": "https://registry.npmjs.org/psl/-/psl-1.1.29.tgz",
+			"integrity": "sha512-AeUmQ0oLN02flVHXWh9sSJF7mcdFq0ppid/JkErufc3hGIV/AMa8Fo9VgDo/cT2jFdOWoFvHp90qqBH54W+gjQ=="
 		},
 		"public-encrypt": {
 			"version": "4.0.2",
@@ -6404,9 +6345,9 @@
 			"integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM="
 		},
 		"randomatic": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.0.0.tgz",
-			"integrity": "sha512-VdxFOIEY3mNO5PtSRkkle/hPJDHvQhK21oa73K4yAc9qmp6N429gAyF1gZMOTMeS0/AYzaV/2Trcef+NaIonSA==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.1.0.tgz",
+			"integrity": "sha512-KnGPVE0lo2WoXxIZ7cPR8YBpiol4gsSuOwDSg410oHh80ZMp5EiypNqL2K4Z77vJn6lB5rap7IkAmcUlalcnBQ==",
 			"requires": {
 				"is-number": "^4.0.0",
 				"kind-of": "^6.0.0",
@@ -6675,37 +6616,32 @@
 			"integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ="
 		},
 		"request": {
-			"version": "2.79.0",
-			"resolved": "https://registry.npmjs.org/request/-/request-2.79.0.tgz",
-			"integrity": "sha1-Tf5b9r6LjNw3/Pk+BLZVd3InEN4=",
+			"version": "2.87.0",
+			"resolved": "https://registry.npmjs.org/request/-/request-2.87.0.tgz",
+			"integrity": "sha512-fcogkm7Az5bsS6Sl0sibkbhcKsnyon/jV1kF3ajGmF0c8HrttdKTPRT9hieOaQHA5HEq6r8OyWOo/o781C1tNw==",
 			"requires": {
-				"aws-sign2": "~0.6.0",
-				"aws4": "^1.2.1",
-				"caseless": "~0.11.0",
+				"aws-sign2": "~0.7.0",
+				"aws4": "^1.6.0",
+				"caseless": "~0.12.0",
 				"combined-stream": "~1.0.5",
-				"extend": "~3.0.0",
+				"extend": "~3.0.1",
 				"forever-agent": "~0.6.1",
-				"form-data": "~2.1.1",
-				"har-validator": "~2.0.6",
-				"hawk": "~3.1.3",
-				"http-signature": "~1.1.0",
+				"form-data": "~2.3.1",
+				"har-validator": "~5.0.3",
+				"http-signature": "~1.2.0",
 				"is-typedarray": "~1.0.0",
 				"isstream": "~0.1.2",
 				"json-stringify-safe": "~5.0.1",
-				"mime-types": "~2.1.7",
-				"oauth-sign": "~0.8.1",
-				"qs": "~6.3.0",
-				"stringstream": "~0.0.4",
-				"tough-cookie": "~2.3.0",
-				"tunnel-agent": "~0.4.1",
-				"uuid": "^3.0.0"
+				"mime-types": "~2.1.17",
+				"oauth-sign": "~0.8.2",
+				"performance-now": "^2.1.0",
+				"qs": "~6.5.1",
+				"safe-buffer": "^5.1.1",
+				"tough-cookie": "~2.3.3",
+				"tunnel-agent": "^0.6.0",
+				"uuid": "^3.1.0"
 			},
 			"dependencies": {
-				"qs": {
-					"version": "6.3.2",
-					"resolved": "https://registry.npmjs.org/qs/-/qs-6.3.2.tgz",
-					"integrity": "sha1-51vV9uJoEioqDgvaYwslUMFmUCw="
-				},
 				"tough-cookie": {
 					"version": "2.3.4",
 					"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
@@ -6715,9 +6651,9 @@
 					}
 				},
 				"uuid": {
-					"version": "3.2.1",
-					"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
-					"integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA=="
+					"version": "3.3.2",
+					"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+					"integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
 				}
 			}
 		},
@@ -7026,47 +6962,17 @@
 			"integrity": "sha1-kM/xnQLgcCf9dn9erT57ldHnOAw="
 		},
 		"serve-index": {
-			"version": "1.8.0",
-			"resolved": "https://registry.npmjs.org/serve-index/-/serve-index-1.8.0.tgz",
-			"integrity": "sha1-fF2WwT+xMRAfk8HFd0+FFqHnjTs=",
+			"version": "1.9.1",
+			"resolved": "https://registry.npmjs.org/serve-index/-/serve-index-1.9.1.tgz",
+			"integrity": "sha1-03aNabHn2C5c4FD/9bRTvqEqkjk=",
 			"requires": {
-				"accepts": "~1.3.3",
-				"batch": "0.5.3",
-				"debug": "~2.2.0",
+				"accepts": "~1.3.4",
+				"batch": "0.6.1",
+				"debug": "2.6.9",
 				"escape-html": "~1.0.3",
-				"http-errors": "~1.5.0",
-				"mime-types": "~2.1.11",
-				"parseurl": "~1.3.1"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-					"integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
-					"requires": {
-						"ms": "0.7.1"
-					}
-				},
-				"http-errors": {
-					"version": "1.5.1",
-					"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.5.1.tgz",
-					"integrity": "sha1-eIwNLB3iyBuebowBhDtrl+uSB1A=",
-					"requires": {
-						"inherits": "2.0.3",
-						"setprototypeof": "1.0.2",
-						"statuses": ">= 1.3.1 < 2"
-					}
-				},
-				"ms": {
-					"version": "0.7.1",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-					"integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg="
-				},
-				"setprototypeof": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.2.tgz",
-					"integrity": "sha1-gaVSFB7BBLiOic44MQOtXGZWTQg="
-				}
+				"http-errors": "~1.6.2",
+				"mime-types": "~2.1.17",
+				"parseurl": "~1.3.2"
 			}
 		},
 		"serve-static": {
@@ -7247,24 +7153,81 @@
 				}
 			}
 		},
-		"sntp": {
-			"version": "1.0.9",
-			"resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
-			"integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
-			"requires": {
-				"hoek": "2.x.x"
-			}
-		},
 		"socket.io": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/socket.io/-/socket.io-2.0.4.tgz",
-			"integrity": "sha1-waRZDO/4fs8TxyZS8Eb3FrKeYBQ=",
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/socket.io/-/socket.io-2.1.1.tgz",
+			"integrity": "sha512-rORqq9c+7W0DAK3cleWNSyfv/qKXV99hV4tZe+gGLfBECw3XEhBy7x85F3wypA9688LKjtwO9pX9L33/xQI8yA==",
 			"requires": {
-				"debug": "~2.6.6",
-				"engine.io": "~3.1.0",
+				"debug": "~3.1.0",
+				"engine.io": "~3.2.0",
+				"has-binary2": "~1.0.2",
 				"socket.io-adapter": "~1.1.0",
-				"socket.io-client": "2.0.4",
-				"socket.io-parser": "~3.1.1"
+				"socket.io-client": "2.1.1",
+				"socket.io-parser": "~3.2.0"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"engine.io-client": {
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-3.2.1.tgz",
+					"integrity": "sha512-y5AbkytWeM4jQr7m/koQLc5AxpRKC1hEVUb/s1FUAWEJq5AzJJ4NLvzuKPuxtDi5Mq755WuDvZ6Iv2rXj4PTzw==",
+					"requires": {
+						"component-emitter": "1.2.1",
+						"component-inherit": "0.0.3",
+						"debug": "~3.1.0",
+						"engine.io-parser": "~2.1.1",
+						"has-cors": "1.1.0",
+						"indexof": "0.0.1",
+						"parseqs": "0.0.5",
+						"parseuri": "0.0.5",
+						"ws": "~3.3.1",
+						"xmlhttprequest-ssl": "~1.5.4",
+						"yeast": "0.1.2"
+					}
+				},
+				"isarray": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.1.tgz",
+					"integrity": "sha1-o32U7ZzaLVmGXJ92/llu4fM4dB4="
+				},
+				"socket.io-client": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-2.1.1.tgz",
+					"integrity": "sha512-jxnFyhAuFxYfjqIgduQlhzqTcOEQSn+OHKVfAxWaNWa7ecP7xSNk2Dx/3UEsDcY7NcFafxvNvKPmmO7HTwTxGQ==",
+					"requires": {
+						"backo2": "1.0.2",
+						"base64-arraybuffer": "0.1.5",
+						"component-bind": "1.0.0",
+						"component-emitter": "1.2.1",
+						"debug": "~3.1.0",
+						"engine.io-client": "~3.2.0",
+						"has-binary2": "~1.0.2",
+						"has-cors": "1.1.0",
+						"indexof": "0.0.1",
+						"object-component": "0.0.3",
+						"parseqs": "0.0.5",
+						"parseuri": "0.0.5",
+						"socket.io-parser": "~3.2.0",
+						"to-array": "0.1.4"
+					}
+				},
+				"socket.io-parser": {
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-3.2.0.tgz",
+					"integrity": "sha512-FYiBx7rc/KORMJlgsXysflWx/RIvtqZbyGLlHZvjfmPTPeuD/I8MaW7cfFrj5tRltICJdgwflhfZ3NVVbVLFQA==",
+					"requires": {
+						"component-emitter": "1.2.1",
+						"debug": "~3.1.0",
+						"isarray": "2.0.1"
+					}
+				}
 			}
 		},
 		"socket.io-adapter": {
@@ -7434,13 +7397,6 @@
 				"jsbn": "~0.1.0",
 				"safer-buffer": "^2.0.2",
 				"tweetnacl": "~0.14.0"
-			},
-			"dependencies": {
-				"assert-plus": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-					"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
-				}
 			}
 		},
 		"static-extend": {
@@ -7561,11 +7517,6 @@
 			"requires": {
 				"safe-buffer": "~5.1.0"
 			}
-		},
-		"stringstream": {
-			"version": "0.0.6",
-			"resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.6.tgz",
-			"integrity": "sha512-87GEBAkegbBcweToUrdzf3eLhWNg06FJTebl4BVJz/JgWy8CvEr9dRtX5qWphiynMSQlxxi+QqN0z5T32SLlhA=="
 		},
 		"strip-ansi": {
 			"version": "3.0.1",
@@ -7779,9 +7730,9 @@
 			}
 		},
 		"tough-cookie": {
-			"version": "2.4.2",
-			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.2.tgz",
-			"integrity": "sha512-vahm+X8lSV/KjXziec8x5Vp0OTC9mq8EVCOApIsRAooeuMPSO8aT7PFACYkaL0yZ/3hVqw+8DzhCJwl8H2Ad6w==",
+			"version": "2.4.3",
+			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
+			"integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
 			"requires": {
 				"psl": "^1.1.24",
 				"punycode": "^1.4.1"
@@ -7825,9 +7776,12 @@
 			"integrity": "sha1-oVe6QC2iTpv5V/mqadUk7tQpAaY="
 		},
 		"tunnel-agent": {
-			"version": "0.4.3",
-			"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
-			"integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us="
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+			"integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+			"requires": {
+				"safe-buffer": "^5.0.1"
+			}
 		},
 		"tweetnacl": {
 			"version": "0.14.5",
@@ -8097,12 +8051,6 @@
 			"resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz",
 			"integrity": "sha1-Z+LoY3lyFVMN/zGOW/nc6/1Hsho="
 		},
-		"uws": {
-			"version": "9.14.0",
-			"resolved": "https://registry.npmjs.org/uws/-/uws-9.14.0.tgz",
-			"integrity": "sha512-HNMztPP5A1sKuVFmdZ6BPVpBQd5bUjNC8EFMFiICK+oho/OQsAJy5hnIx4btMHiOk8j04f/DbIlqnEZ9d72dqg==",
-			"optional": true
-		},
 		"v8flags": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/v8flags/-/v8flags-2.1.1.tgz",
@@ -8138,13 +8086,6 @@
 				"assert-plus": "^1.0.0",
 				"core-util-is": "1.0.2",
 				"extsprintf": "^1.2.0"
-			},
-			"dependencies": {
-				"assert-plus": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-					"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
-				}
 			}
 		},
 		"vinyl": {

--- a/packages/venia-concept/package-lock.json
+++ b/packages/venia-concept/package-lock.json
@@ -7404,9 +7404,9 @@
       }
     },
     "react": {
-      "version": "16.3.2",
-      "resolved": "https://registry.npmjs.org/react/-/react-16.3.2.tgz",
-      "integrity": "sha512-o5GPdkhciQ3cEph6qgvYB7LTOHw/GB0qRI6ZFNugj49qJCFfgHwVNjZ5u+b7nif4vOeMIOuYj3CeYe2IBD74lg==",
+      "version": "16.4.2",
+      "resolved": "https://registry.npmjs.org/react/-/react-16.4.2.tgz",
+      "integrity": "sha512-dMv7YrbxO4y2aqnvA7f/ik9ibeLSHQJTI6TrYAenPSaQ6OXfb+Oti+oJiy8WBxgRzlKatYqtCjphTgDSCEiWFg==",
       "requires": {
         "fbjs": "^0.8.16",
         "loose-envify": "^1.1.0",
@@ -7434,9 +7434,9 @@
       }
     },
     "react-dom": {
-      "version": "16.3.2",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.3.2.tgz",
-      "integrity": "sha512-MMPko3zYncNrz/7gG17wJWUREZDvskZHXOwbttzl0F0L3wDmToyuETuo/r8Y5yvDejwYcRyWI1lvVBjLJWFwKA==",
+      "version": "16.4.2",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.4.2.tgz",
+      "integrity": "sha512-Usl73nQqzvmJN+89r97zmeUpQDKDlh58eX6Hbs/ERdDHzeBzWy+ENk7fsGQ+5KxArV1iOFPT46/VneklK9zoWw==",
       "requires": {
         "fbjs": "^0.8.16",
         "loose-envify": "^1.1.0",


### PR DESCRIPTION
<!-- (REQUIRED) What is the nature of this PR? -->

## This PR is a:

[ ] New feature
[x] Enhancement/Optimization
[ ] Refactor
[ ] Bugfix
[ ] Test for existing code
[ ] Documentation

<!-- (REQUIRED) What does this PR change? -->

## Summary

When this pull request is merged, it will update package-lock.json to the latest in-range dependencies, using NPM 6, in all packages.

<!-- (OPTIONAL) What other information can you provide about this PR? -->

## Additional information

This is in preparation for a refresh of Greenkeeper, and also to fix some security vulnerabilities in the older `pwa-devdocs` deps.

<!--
Thank you for your contribution!

Before submitting this pull request, please make sure you have read our Contribution Guidelines and your PR meets our contribution standards:
https://github.com/magento-research/pwa-studio/blob/master/.github/CONTRIBUTION.md

Please fill out as much information as you can about your PR to help speed up the review process.
If your PR addresses an existing GitHub Issue, please refer to it in the title or Additional Information section to make the connection.

We may ask you for changes in your PR in order to meet the standards set in our Contribution Guidelines. PR's that do not comply with our guidelines may be closed at the maintainers' discretion.

Feel free to remove this section before creating this PR.
-->
