### PR TITLE
Replace <a href=""> with <Link to="">

### DIFF
--- a/packages/venia-concept/src/RootComponents/Category/category.js
+++ b/packages/venia-concept/src/RootComponents/Category/category.js
@@ -18,6 +18,7 @@ const categoryQuery = gql`
                     id
                     name
                     small_image
+                    url_key
                     price {
                         regularPrice {
                             amount {

--- a/packages/venia-concept/src/__mocks__/@magento/peregrine.js
+++ b/packages/venia-concept/src/__mocks__/@magento/peregrine.js
@@ -1,0 +1,8 @@
+import { createElement } from 'react';
+
+/**
+ * the Price component from @magento/peregrine
+ * has browser-specific functionality and cannot
+ * currently by rendered in the test environment
+ */
+export const Price = () => <div />;

--- a/packages/venia-concept/src/components/CategoryList/categoryList.js
+++ b/packages/venia-concept/src/components/CategoryList/categoryList.js
@@ -1,5 +1,6 @@
 import { Component, createElement } from 'react';
 import { string, number, shape } from 'prop-types';
+import { Link } from 'react-router-dom';
 import { Query } from 'react-apollo';
 import gql from 'graphql-tag';
 import classify from 'src/classify';
@@ -66,9 +67,9 @@ class CategoryList extends Component {
                         return (
                             <div className={classes.content}>
                                 {data.category.children.map((item, index) => (
-                                    <a
+                                    <Link
                                         className={classes.item}
-                                        href={`/${
+                                        to={`/${
                                             item.url_key
                                         }${categoryUrlSuffix}`}
                                         key={index}
@@ -87,7 +88,7 @@ class CategoryList extends Component {
                                         <span className={classes.name}>
                                             {item.name}
                                         </span>
-                                    </a>
+                                    </Link>
                                 ))}
                             </div>
                         );

--- a/packages/venia-concept/src/components/Gallery/__tests__/item.spec.js
+++ b/packages/venia-concept/src/components/Gallery/__tests__/item.spec.js
@@ -1,6 +1,7 @@
 import { createElement } from 'react';
-import { configure, shallow } from 'enzyme';
+import { configure, mount, shallow } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
+import { BrowserRouter } from 'react-router-dom';
 
 import Item from '../item';
 
@@ -25,6 +26,7 @@ const validItem = {
     id: 1,
     name: 'Test Product',
     small_image: '/foo/bar/pic.png',
+    url_key: 'strive-shoulder-pack',
     price: {
         regularPrice: {
             amount: {
@@ -55,6 +57,24 @@ test('passes classnames to the placeholder item', () => {
         .dive();
 
     expect(wrapper.hasClass(classes.root_pending));
+});
+
+test('renders Anchor elements for navigating to a PDP', () => {
+    const wrapper = mount(
+        <BrowserRouter>
+            <Item classes={classes} item={validItem} />
+        </BrowserRouter>
+    );
+    const expectedSelector = `a[href="/${validItem.url_key}.html"]`;
+    const imageLink = wrapper
+        .find({ className: classes.images })
+        .find(expectedSelector);
+    const nameLink = wrapper
+        .find({ className: classes.name })
+        .find(expectedSelector);
+
+    expect(imageLink).toHaveLength(1);
+    expect(nameLink).toHaveLength(1);
 });
 
 /**

--- a/packages/venia-concept/src/components/Gallery/item.js
+++ b/packages/venia-concept/src/components/Gallery/item.js
@@ -1,6 +1,7 @@
 import { Component, createElement } from 'react';
 import { string, number, shape, func, bool } from 'prop-types';
 import { Price } from '@magento/peregrine';
+import { Link } from 'react-router-dom';
 import classify from 'src/classify';
 import { transparentPlaceholder } from 'src/shared/images';
 import { makeProductMediaPath } from 'src/util/makeMediaPath';
@@ -16,6 +17,9 @@ const ItemPlaceholder = ({ children, classes }) => (
         <div className={classes.price_pending} />
     </div>
 );
+
+// TODO: get productUrlSuffix from graphql when it is ready
+const productUrlSuffix = '.html';
 
 class GalleryItem extends Component {
     static propTypes = {
@@ -37,6 +41,7 @@ class GalleryItem extends Component {
             id: number.isRequired,
             name: string.isRequired,
             small_image: string.isRequired,
+            url_key: string.isRequired,
             price: shape({
                 regularPrice: shape({
                     amount: shape({
@@ -67,17 +72,18 @@ class GalleryItem extends Component {
             );
         }
 
-        const { name, price } = item;
+        const { name, price, url_key } = item;
+        const productLink = `/${url_key}${productUrlSuffix}`;
 
         return (
             <div className={classes.root}>
-                <div className={classes.images}>
+                <Link to={productLink} className={classes.images}>
                     {this.renderImagePlaceholder()}
                     {this.renderImage()}
-                </div>
-                <div className={classes.name}>
+                </Link>
+                <Link to={productLink} className={classes.name}>
                     <span>{name}</span>
-                </div>
+                </Link>
                 <div className={classes.price}>
                     <Price
                         value={price.regularPrice.amount.value}

--- a/packages/venia-concept/src/components/Header/header.js
+++ b/packages/venia-concept/src/components/Header/header.js
@@ -1,5 +1,6 @@
 import { Component, createElement } from 'react';
 import PropTypes from 'prop-types';
+import { Link } from 'react-router-dom';
 
 import classify from 'src/classify';
 import Icon from 'src/components/Icon';
@@ -28,13 +29,15 @@ class Header extends Component {
         return (
             <header className={classes.root}>
                 <div className={classes.toolbar}>
-                    <img
-                        className={classes.logo}
-                        src={logo}
-                        height="24"
-                        alt="Venia"
-                        title="Venia"
-                    />
+                    <Link to="/">
+                        <img
+                            className={classes.logo}
+                            src={logo}
+                            height="24"
+                            alt="Venia"
+                            title="Venia"
+                        />
+                    </Link>
                     <div className={classes.primaryActions}>
                         <NavTrigger>
                             <Icon name="menu" />


### PR DESCRIPTION
Any link that currently works with a regular `<a>` should just be a `<Link>`
element instead. 

This PR adds the `<Link>` element in a few places to reduce the amount of full-page reloads.

## This PR is a:

[ ] New feature
[x] Enhancement/Optimization
[ ] Refactor
[ ] Bugfix
[ ] Test for existing code
[ ] Documentation

<!-- (REQUIRED) What does this PR change? -->
1. wraps the logo in a <Link> to allow navigation back to the store home
1. allow navigation from Category -> Product 
1. added the `IntlPolyfill` to the item spec, since Jest cannot handle the Price rendering in the item component, and we need to do a `mount` or `render` in order to make this test useful

## Summary

When this pull request is merged, it will prevent page reloads for some basic navigation items

<!-- (OPTIONAL) What other information can you provide about this PR? -->

<!--
Thank you for your contribution!

Before submitting this pull request, please make sure you have read our Contribution Guidelines and your PR meets our contribution standards:
https://github.com/magento-research/pwa-studio/blob/master/.github/CONTRIBUTION.md

Please fill out as much information as you can about your PR to help speed up the review process.
If your PR addresses an existing GitHub Issue, please refer to it in the title or Additional Information section to make the connection.

We may ask you for changes in your PR in order to meet the standards set in our Contribution Guidelines. PR's that do not comply with our guidelines may be closed at the maintainers' discretion.

Feel free to remove this section before creating this PR.
-->
