### PR TITLE
fix: revert eslint-config before pragma merge

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1426,9 +1426,9 @@
       }
     },
     "@magento/eslint-config": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@magento/eslint-config/-/eslint-config-1.1.0.tgz",
-      "integrity": "sha512-zZNCjUBBZpHoMOhtin9bEEUGMhCxARdBQpCSEPynob1JrKOfUljCMYIVsj3qCnDathcAdK2LT0O1shizEw+U4w==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@magento/eslint-config/-/eslint-config-1.0.0.tgz",
+      "integrity": "sha512-Q/fg1WkQszHxYxyS/tacwlB4xxzOs+n7r6xRyzqmcEW5NYu0bitzoQh63HzQg7mZjjRxCO3jdQE8MoNlb38YEA==",
       "dev": true
     },
     "@magento/peregrine": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "watch:venia-dev-server": "cd packages/venia-concept && nodemon --watch ../pwa-buildpack/dist --watch webpack.config.js --delay 1 --ext js,json --exec npm run-script watch; cd - >/dev/null"
   },
   "devDependencies": {
-    "@magento/eslint-config": "^1.0.0",
+    "@magento/eslint-config": "1.0.0",
     "@storybook/addon-actions": "^3.4.2",
     "@storybook/addons": "^3.4.6",
     "@storybook/react": "^3.4.2",


### PR DESCRIPTION
<!-- (REQUIRED) What is the nature of this PR? -->

## This PR is a:

[ ] New feature
[ ] Enhancement/Optimization
[ ] Refactor
[x] Bugfix
[ ] Test for existing code
[ ] Documentation

<!-- (REQUIRED) What does this PR change? -->

## Summary

When this pull request is merged, it will will fix the build failures that began with magento/eslint-config 1.2.3: https://github.com/magento-research/magento-eslint/commit/62c434df92917d8b30edd4374e57f8ef545bcbd1#diff-168726dbe96b3ce427e7fedce31bb0bcL5 I should not have published this as a minor version, because it was then swept via semver into `pwa-studio` before #229 was merged.

This temporarily fixes the version to `1.0.0`.
<!-- (OPTIONAL) What other information can you provide about this PR? -->

## Additional information

<!--
Thank you for your contribution!

Before submitting this pull request, please make sure you have read our Contribution Guidelines and your PR meets our contribution standards:
https://github.com/magento-research/pwa-studio/blob/master/.github/CONTRIBUTION.md

Please fill out as much information as you can about your PR to help speed up the review process.
If your PR addresses an existing GitHub Issue, please refer to it in the title or Additional Information section to make the connection.

We may ask you for changes in your PR in order to meet the standards set in our Contribution Guidelines. PR's that do not comply with our guidelines may be closed at the maintainers' discretion.

Feel free to remove this section before creating this PR.
-->
