### PR TITLE
fix: buildpack handles http, venia forces https

### DIFF
--- a/packages/pwa-buildpack/src/WebpackTools/PWADevServer.js
+++ b/packages/pwa-buildpack/src/WebpackTools/PWADevServer.js
@@ -217,7 +217,7 @@ const PWADevServer = {
             );
         }
         devServerConfig.publicPath = url.format({
-            protocol: 'https:',
+            protocol: config.provideSSLCert ? 'https:' : 'http:',
             hostname: devServerConfig.host,
             port: devServerConfig.port,
             pathname: config.publicPath

--- a/packages/pwa-buildpack/src/WebpackTools/__tests__/PWADevServer.spec.js
+++ b/packages/pwa-buildpack/src/WebpackTools/__tests__/PWADevServer.spec.js
@@ -303,7 +303,10 @@ test('.configure() returns a configuration object for the `devServer` property o
             cert: 'fakeCert2'
         },
         host: expect.stringMatching(/horton\-(\w){4,5}\.local\.pwadev/),
-        port: 8765
+        port: 8765,
+        publicPath: expect.stringMatching(
+            /horton\-(\w){4,5}\.local.pwadev:8765\/full\/path\/to\/publicPath/
+        )
     });
 });
 
@@ -320,6 +323,7 @@ test('.configure() is backwards compatible with `id` param', async () => {
             assets: 'path/to/assets'
         },
         publicPath: 'full/path/to/publicPath',
+        provideSSLCert: true,
         serviceWorkerFileName: 'swname.js',
         backendDomain: 'https://magento.backend.domain'
     };
@@ -327,7 +331,34 @@ test('.configure() is backwards compatible with `id` param', async () => {
     const devServer = await PWADevServer.configure(config);
 
     expect(devServer).toMatchObject({
-        host: 'samiam.local.pwadev'
+        host: 'samiam.local.pwadev',
+        publicPath: 'https://samiam.local.pwadev:8765/full/path/to/publicPath'
+    });
+});
+
+test('.configure() reluctantly handles unsecure http', async () => {
+    simulate
+        .portSavedForNextHostname(8765)
+        .aFreePortWasFound(8765)
+        .hostResolvesLoopback();
+
+    const config = {
+        https: false,
+        id: 'samiam',
+        paths: {
+            output: 'path/to/static',
+            assets: 'path/to/assets'
+        },
+        publicPath: 'full/path/to/publicPath',
+        serviceWorkerFileName: 'swname.js',
+        backendDomain: 'https://magento.backend.domain'
+    };
+
+    const devServer = await PWADevServer.configure(config);
+
+    expect(devServer).toMatchObject({
+        host: 'samiam.local.pwadev',
+        publicPath: 'http://samiam.local.pwadev:8765/full/path/to/publicPath'
     });
 });
 

--- a/packages/pwa-buildpack/src/WebpackTools/plugins/DevServerReadyNotifierPlugin.js
+++ b/packages/pwa-buildpack/src/WebpackTools/plugins/DevServerReadyNotifierPlugin.js
@@ -12,7 +12,7 @@ class DevServerReadyNotifierPlugin {
             );
         }
         this.url = url.format({
-            protocol: 'https',
+            protocol: devServer.https ? 'https:' : 'http:',
             // webpack-dev-server does not comply with the WHATWG URL
             // format specification that `host` includes a port number,
             // and `hostname` does not

--- a/packages/pwa-buildpack/src/WebpackTools/plugins/__tests__/DevServerReadyNotifierPlugin.spec.js
+++ b/packages/pwa-buildpack/src/WebpackTools/plugins/__tests__/DevServerReadyNotifierPlugin.spec.js
@@ -12,6 +12,7 @@ beforeEach(() => {
         plugin: jest.fn()
     };
     notifier = new DevServerReadyNotifierPlugin({
+        https: true,
         host: 'fake.hostname',
         port: 8765
     });
@@ -39,6 +40,26 @@ test('logs notification to console', () => {
     const consoleOutput = stripAnsi(console.log.mock.calls[0][0]);
     expect(consoleOutput).toMatch(
         'PWADevServer ready at https://fake.hostname:8765'
+    );
+});
+
+test('handles unsecure URLs', () => {
+    compiler = {
+        plugin: jest.fn()
+    };
+    notifier = new DevServerReadyNotifierPlugin({
+        https: false,
+        host: 'unsecure.hostname',
+        port: 8765
+    });
+    notifier.apply(compiler);
+    const notifierFn = compiler.plugin.mock.calls[0][1];
+    notifierFn();
+    jest.runAllTimers();
+
+    const consoleOutput = stripAnsi(console.log.mock.calls[0][0]);
+    expect(consoleOutput).toMatch(
+        'PWADevServer ready at http://unsecure.hostname:8765'
     );
 });
 

--- a/packages/venia-concept/webpack.config.js
+++ b/packages/venia-concept/webpack.config.js
@@ -135,6 +135,7 @@ module.exports = async function(env) {
             publicPath: process.env.MAGENTO_BACKEND_PUBLIC_PATH,
             backendDomain: process.env.MAGENTO_BACKEND_DOMAIN,
             paths: themePaths,
+            provideSSLCert: true,
             id: 'magento-venia'
         });
 


### PR DESCRIPTION
<!-- (REQUIRED) What is the nature of this PR? -->

## This PR is a:

[ ] New feature
[ ] Enhancement/Optimization
[ ] Refactor
[x] Bugfix
[ ] Test for existing code
[ ] Documentation

<!-- (REQUIRED) What does this PR change? -->

## Summary

When this pull request is merged, it will allow Buildpack, specifically PWADevServer and DevServerNotifierPlugin, to handle and display unsecure HTTP domains, which it will do by default unless devServer is configured with `provideSSLCert: true`.

It will also update Venia's Webpack config to add `provideSSLCert: true`.
