### PR TITLE
Update quick setup steps to be clearer based on feedback from community

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,13 +74,11 @@ Follow these steps to install the dependencies for all the packages in the proje
 1. Clone the repository.
 2. Navigate to the root of the repository from the command line
 3. Run `npm install`
-4. Watch the bootstrapping take place.
-5. Create a `packages/venia-concept/.env` file (or set environment variables manually)
+4. Copy `packages/venia-concept/example.env` to `packages/venia-concept/.env`
+5. Uncomment the line for `MAGENTO_BACKEND_DOMAIN` in `packages/venia-concept/.env`, and set `MAGENTO_BACKEND_DOMAIN` to the fully-qualified URL of a Magento store running `2.3`.
 6. Set the environment variable `MAGENTO_BACKEND_DOMAIN` to the URL of the backing Magento instance you are using
 7. On your first install, run `npm run build` from package root.
 8. To run the Venia storefront development experience, run `npm run watch:venia` from package root.
-9.  To run the full PWA Studio developer experience, with Venia hot-reloading and concurrent Buildpack/Peregrine rebuilds, run `npm run watch:all` from package root.
-10.  To run the staging environment, which uses more compressed assets and more closely reflects production, run `npm run stage:venia` from package root. (This requires that you first run `npm run build` to generate the artifacts being served.)
 
 ## Troubleshooting
 


### PR DESCRIPTION
Added in steps for happy path, removed reference to `bootstrapping` because we don't describe what that is (monorepo stuff), and removed lines that are not critical to the initial setup.