### PR TITLE
fix(venia): rm staleGuestCartId on error

### DIFF
--- a/packages/venia-concept/src/reducers/cart.js
+++ b/packages/venia-concept/src/reducers/cart.js
@@ -3,6 +3,8 @@ import { handleActions } from 'redux-actions';
 import actions from 'src/actions/cart';
 import checkoutActions from 'src/actions/checkout';
 
+import omit from 'src/util/omit';
+
 export const name = 'cart';
 
 const initialState = {
@@ -24,7 +26,7 @@ const reducerMap = {
     },
     [actions.getDetails.receive]: (state, { payload, error }) => {
         if (error) {
-            return state;
+            return omit(state, 'guestCartId');
         }
 
         return {

--- a/packages/venia-concept/src/util/omit.js
+++ b/packages/venia-concept/src/util/omit.js
@@ -1,0 +1,35 @@
+/**
+ * Return a copy of an object with one named property omitted.
+ * Short version of lodash.omit.
+ *
+ * Useful when a reducer needs to drop something from state, without using
+ * the `delete` keyword to mutate the existing state. The `delete` keyword
+ * is also a deopt.
+ *
+ * @param {object} obj -- Object to copy
+ * @param {string} omitKey -- Property name to omit
+ * @returns {object} Copy of the object with the specified key omitted.
+ *
+ * @example
+ *
+ * ```js
+ * const musketeers = {
+ *   athos: true,
+ *   porthos: true,
+ *   aramis: true
+ * };
+ *
+ * console.lot(omit(musketeers, 'athos'));
+ *
+ * {
+ *   porthos: true,
+ *   aramis: true
+ * }
+ */
+
+module.exports = (obj, omitKey) =>
+    Object.entries(obj).reduce(
+        (out, [key, value]) =>
+            key === omitKey ? out : ((out[key] = value), out),
+        {}
+    );


### PR DESCRIPTION
Fixes #344.

The error was caused by a stale guestCartId whose corresponding cart in the API was no longer available. Since we don't have GraphQL for sessions yet, the guestCartId is stored in localStorage as well as in the Redux store. We were clearing it from localStorage on error, but forgetting to clear it from the store itself.

This fixes that!

<!-- (REQUIRED) What is the nature of this PR? -->

## This PR is a:

[ ] New feature
[ ] Enhancement/Optimization
[ ] Refactor
[x] Bugfix
[ ] Test for existing code
[ ] Documentation