### PR TITLE
Connect order confirmation page to Redux

### DIFF
--- a/packages/venia-concept/src/actions/checkout/__tests__/asyncActions.spec.js
+++ b/packages/venia-concept/src/actions/checkout/__tests__/asyncActions.spec.js
@@ -10,6 +10,7 @@ import {
     submitInput,
     submitOrder
 } from '../asyncActions';
+import checkoutReceiptActions from 'src/components/Checkout/Receipt/actions';
 
 jest.mock('src/store');
 
@@ -180,6 +181,13 @@ test('submitOrder thunk dispatches actions on success', async () => {
     await submitOrder()(...thunkArgs);
 
     expect(dispatch).toHaveBeenNthCalledWith(1, actions.order.submit());
+    expect(dispatch).toHaveBeenNthCalledWith(
+        2,
+        checkoutReceiptActions.setOrderInformation({
+            id: response,
+            billing_address: undefined
+        })
+    );
     expect(dispatch).toHaveBeenNthCalledWith(3, actions.order.accept(response));
     expect(dispatch).toHaveBeenCalledTimes(3);
 });

--- a/packages/venia-concept/src/actions/checkout/__tests__/asyncActions.spec.js
+++ b/packages/venia-concept/src/actions/checkout/__tests__/asyncActions.spec.js
@@ -180,8 +180,8 @@ test('submitOrder thunk dispatches actions on success', async () => {
     await submitOrder()(...thunkArgs);
 
     expect(dispatch).toHaveBeenNthCalledWith(1, actions.order.submit());
-    expect(dispatch).toHaveBeenNthCalledWith(2, actions.order.accept(response));
-    expect(dispatch).toHaveBeenCalledTimes(2);
+    expect(dispatch).toHaveBeenNthCalledWith(3, actions.order.accept(response));
+    expect(dispatch).toHaveBeenCalledTimes(3);
 });
 
 test('submitOrder thunk dispatches actions on failure', async () => {

--- a/packages/venia-concept/src/actions/checkout/asyncActions.js
+++ b/packages/venia-concept/src/actions/checkout/asyncActions.js
@@ -3,6 +3,7 @@ import { RestApi } from '@magento/peregrine';
 import { closeDrawer } from 'src/actions/app';
 import { clearGuestCartId, getCartDetails } from 'src/actions/cart';
 import { getCountries } from 'src/actions/directory';
+import checkoutReceiptActions from 'src/components/Checkout/Receipt/actions';
 import actions from './actions';
 
 const { request } = RestApi.Magento2;
@@ -93,6 +94,12 @@ export const submitOrder = () =>
                 }
             );
 
+            dispatch(
+                checkoutReceiptActions.setOrderInformation(
+                    getOrderInformation(getState(), response)
+                )
+            );
+
             dispatch(actions.order.accept(response));
             clearGuestCartId();
         } catch (error) {
@@ -130,3 +137,11 @@ export function formatAddress(address = {}, countries = []) {
         ...address
     };
 }
+
+export const getOrderInformation = (
+    { cart: { details: { billing_address } = {} } },
+    orderId
+) => ({
+    id: orderId,
+    billing_address
+});

--- a/packages/venia-concept/src/components/Checkout/Receipt/__tests__/actions.spec.js
+++ b/packages/venia-concept/src/components/Checkout/Receipt/__tests__/actions.spec.js
@@ -1,0 +1,27 @@
+import actions from '../actions';
+
+const payload = {};
+
+test('setOrderInformation.toString() returns the proper action type', () => {
+    expect(actions.setOrderInformation.toString()).toBe(
+        'checkoutReceipt/SET_ORDER_INFORMATION'
+    );
+});
+
+test('setOrderInformation() returns a proper action object', () => {
+    expect(actions.setOrderInformation(payload)).toEqual({
+        type: 'checkoutReceipt/SET_ORDER_INFORMATION',
+        payload
+    });
+});
+
+test('reset.toString() returns the proper action type', () => {
+    expect(actions.reset.toString()).toBe('checkoutReceipt/RESET');
+});
+
+test('reset() returns a proper action object', () => {
+    expect(actions.reset()).toEqual({
+        type: 'checkoutReceipt/RESET',
+        payload: undefined
+    });
+});

--- a/packages/venia-concept/src/components/Checkout/Receipt/__tests__/receipt.spec.js
+++ b/packages/venia-concept/src/components/Checkout/Receipt/__tests__/receipt.spec.js
@@ -1,37 +1,59 @@
 import React from 'react';
 import { configure, shallow } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
-import Receipt, { CONTINUE_SHOPPING, CREATE_AN_ACCOUNT } from '../receipt';
+import Receipt from '../receipt';
 import Button from 'src/components/Button';
 
 configure({ adapter: new Adapter() });
 
 const classes = {
     header: 'header',
-    textBlock: 'textBlock'
+    textBlock: 'textBlock',
+    resetCheckoutButtonClasses: {},
+    createAccountButtonClasses: {}
 };
 
 test('renders correctly', () => {
     const wrapper = shallow(<Receipt classes={classes} />).dive();
-    expect(
-        wrapper.find(Button).findWhere(x => x.text() === CONTINUE_SHOPPING)
-    ).toHaveLength(1);
-    expect(
-        wrapper.find(Button).findWhere(x => x.text() === CREATE_AN_ACCOUNT)
-    ).toHaveLength(1);
+
     expect(wrapper.find(`.${classes.header}`)).toHaveLength(1);
     expect(wrapper.find(`.${classes.textBlock}`)).toHaveLength(2);
+    expect(wrapper.find(Button)).toHaveLength(2);
 });
 
-test('pressing `continue shopping` leads to calling handler', () => {
+test('calls `resetCheckout` when `Continue Shopping` button is pressed', () => {
     const resetCheckout = jest.fn();
 
-    const wrapper = shallow(<Receipt resetCheckout={resetCheckout} />).dive();
+    const wrapper = shallow(
+        <Receipt resetCheckout={resetCheckout} classes={classes} />
+    ).dive();
     wrapper
         .find(Button)
-        .findWhere(x => x.text() === CONTINUE_SHOPPING)
+        .findWhere(
+            el => el.props().classes === classes.resetCheckoutButtonClasses
+        )
         .first()
-        .parent()
         .simulate('click');
     expect(resetCheckout).toBeCalled();
+});
+
+test('calls `handleCreateAccount` when `Create an Account` button is pressed', () => {
+    const handleCreateAccountMock = jest.fn();
+
+    const wrapper = shallow(
+        <Receipt
+            handleCreateAccount={handleCreateAccountMock}
+            classes={classes}
+        />
+    ).dive();
+
+    wrapper
+        .find(Button)
+        .findWhere(
+            el => el.props().classes === classes.createAccountButtonClasses
+        )
+        .first()
+        .simulate('click');
+
+    expect(handleCreateAccountMock).toBeCalled();
 });

--- a/packages/venia-concept/src/components/Checkout/Receipt/__tests__/reducer.spec.js
+++ b/packages/venia-concept/src/components/Checkout/Receipt/__tests__/reducer.spec.js
@@ -1,0 +1,14 @@
+import actions from '../actions';
+import reducer from '../reducer';
+
+const order = { id: 1, billing_address: {} };
+
+test('reducer returns initial state', () => {
+    expect(reducer(undefined, {})).toEqual({ order: {} });
+});
+
+test('reducer saves order information', () => {
+    expect(reducer({ order: {} }, actions.setOrderInformation(order))).toEqual({
+        order
+    });
+});

--- a/packages/venia-concept/src/components/Checkout/Receipt/__tests__/selectors.spec.js
+++ b/packages/venia-concept/src/components/Checkout/Receipt/__tests__/selectors.spec.js
@@ -1,0 +1,12 @@
+import { getOrderInformation } from '../selectors';
+
+test('getOrderInformation returns order', () => {
+    const order = { id: 1, billing_address: {} };
+    const state = {
+        checkoutReceipt: {
+            order
+        }
+    };
+
+    expect(getOrderInformation(state)).toEqual(order);
+});

--- a/packages/venia-concept/src/components/Checkout/Receipt/actions.js
+++ b/packages/venia-concept/src/components/Checkout/Receipt/actions.js
@@ -1,0 +1,6 @@
+import { createActions } from 'redux-actions';
+
+const prefix = 'checkoutReceipt';
+const actionTypes = ['SET_ORDER_INFORMATION', 'RESET'];
+
+export default createActions(...actionTypes, { prefix });

--- a/packages/venia-concept/src/components/Checkout/Receipt/index.js
+++ b/packages/venia-concept/src/components/Checkout/Receipt/index.js
@@ -1,1 +1,1 @@
-export { default } from './receipt.js';
+export { default } from './receiptContainer';

--- a/packages/venia-concept/src/components/Checkout/Receipt/receipt.js
+++ b/packages/venia-concept/src/components/Checkout/Receipt/receipt.js
@@ -1,6 +1,5 @@
 import React, { Component } from 'react';
-import { func, shape, string, number } from 'prop-types';
-
+import { func, shape, string } from 'prop-types';
 import classify from 'src/classify';
 import Button, { darkThemeClasses } from 'src/components/Button';
 import defaultClasses from './receipt.css';
@@ -16,16 +15,25 @@ class Receipt extends Component {
             root: string
         }),
         resetCheckout: func.isRequired,
-        orderId: number
+        order: shape({
+            id: string
+        })
     };
 
     static defaultProps = {
-        //TODO: implement fetching of orderId
-        orderId: 777
+        order: {}
     };
 
+    componentWillUnmount() {
+        this.props.reset();
+    }
+
     render() {
-        const { classes, resetCheckout, orderId } = this.props;
+        const {
+            classes,
+            resetCheckout,
+            order: { id }
+        } = this.props;
 
         return (
             <div className={classes.root}>
@@ -35,7 +43,7 @@ class Receipt extends Component {
                     </h2>
                     <div className={classes.textBlock}>
                         Your order # is{' '}
-                        <span className={classes.orderId}>{orderId}</span>
+                        <span className={classes.orderId}>{id}</span>
                         <br />
                         We'll email you an order confirmation with details and
                         tracking info
@@ -55,5 +63,4 @@ class Receipt extends Component {
         );
     }
 }
-
 export default classify(defaultClasses)(Receipt);

--- a/packages/venia-concept/src/components/Checkout/Receipt/receipt.js
+++ b/packages/venia-concept/src/components/Checkout/Receipt/receipt.js
@@ -2,10 +2,13 @@ import React, { Component } from 'react';
 import { func, shape, string } from 'prop-types';
 import classify from 'src/classify';
 import Button, { darkThemeClasses } from 'src/components/Button';
-import defaultClasses from './receipt.css';
+import defaultCssClasses from './receipt.css';
 
-export const CONTINUE_SHOPPING = 'Continue Shopping';
-export const CREATE_AN_ACCOUNT = 'Create an Account';
+const defaultClasses = {
+    ...defaultCssClasses,
+    resetCheckoutButtonClasses: darkThemeClasses,
+    createAccountButtonClasses: darkThemeClasses
+};
 
 class Receipt extends Component {
     static propTypes = {
@@ -14,14 +17,17 @@ class Receipt extends Component {
             footer: string,
             root: string
         }),
-        resetCheckout: func.isRequired,
+        resetCheckout: func,
         order: shape({
             id: string
-        })
+        }),
+        handleCreateAccount: func
     };
 
     static defaultProps = {
-        order: {}
+        order: {},
+        resetCheckout: () => {},
+        handleCreateAccount: () => {}
     };
 
     componentWillUnmount() {
@@ -32,6 +38,7 @@ class Receipt extends Component {
         const {
             classes,
             resetCheckout,
+            handleCreateAccount,
             order: { id }
         } = this.props;
 
@@ -48,15 +55,21 @@ class Receipt extends Component {
                         We'll email you an order confirmation with details and
                         tracking info
                     </div>
-                    <Button classes={darkThemeClasses} onClick={resetCheckout}>
-                        {CONTINUE_SHOPPING}
+                    <Button
+                        classes={classes.resetCheckoutButtonClasses}
+                        onClick={resetCheckout}
+                    >
+                        Continue Shopping
                     </Button>
                     <div className={classes.textBlock}>
                         Track order status and earn rewards for your purchase by
                         creating and account.
                     </div>
-                    <Button classes={darkThemeClasses}>
-                        {CREATE_AN_ACCOUNT}
+                    <Button
+                        classes={classes.createAccountButtonClasses}
+                        onClick={handleCreateAccount}
+                    >
+                        Create an Account
                     </Button>
                 </div>
             </div>

--- a/packages/venia-concept/src/components/Checkout/Receipt/receiptContainer.js
+++ b/packages/venia-concept/src/components/Checkout/Receipt/receiptContainer.js
@@ -1,0 +1,12 @@
+import { connect } from 'react-redux';
+import { resetCheckout } from 'src/actions/checkout';
+import actions from './actions';
+import Receipt from './receipt';
+import { getOrderInformation } from './selectors';
+
+const { reset } = actions;
+
+export default connect(
+    state => ({ order: getOrderInformation(state) }),
+    { resetCheckout, reset }
+)(Receipt);

--- a/packages/venia-concept/src/components/Checkout/Receipt/reducer.js
+++ b/packages/venia-concept/src/components/Checkout/Receipt/reducer.js
@@ -1,0 +1,17 @@
+import { handleActions } from 'redux-actions';
+import actions from './actions';
+
+const initialState = {
+    order: {}
+};
+
+export default handleActions(
+    {
+        [actions.setOrderInformation]: (state, { payload }) => ({
+            ...state,
+            order: payload
+        }),
+        [actions.reset]: () => initialState
+    },
+    initialState
+);

--- a/packages/venia-concept/src/components/Checkout/Receipt/selectors.js
+++ b/packages/venia-concept/src/components/Checkout/Receipt/selectors.js
@@ -1,0 +1,1 @@
+export const getOrderInformation = ({ checkoutReceipt: { order } }) => order;

--- a/packages/venia-concept/src/components/Checkout/flow.js
+++ b/packages/venia-concept/src/components/Checkout/flow.js
@@ -42,13 +42,7 @@ class Flow extends Component {
 
     get child() {
         const { actions, cart, checkout } = this.props;
-        const {
-            beginCheckout,
-            editOrder,
-            resetCheckout,
-            submitInput,
-            submitOrder
-        } = actions;
+        const { beginCheckout, editOrder, submitInput, submitOrder } = actions;
         const { editing, step, submitting } = checkout;
         const { details } = cart;
         const ready = isCartReady(details.items_count);
@@ -74,9 +68,7 @@ class Flow extends Component {
                 return <Form {...stepProps} />;
             }
             case 3: {
-                const stepProps = { resetCheckout };
-
-                return <Receipt {...stepProps} />;
+                return <Receipt />;
             }
             default: {
                 return null;

--- a/packages/venia-concept/src/index.js
+++ b/packages/venia-concept/src/index.js
@@ -13,6 +13,8 @@ import reducer from 'src/reducers/app';
 import userReducer from 'src/reducers/user';
 import cartReducer from 'src/reducers/cart';
 import checkoutReducer from 'src/reducers/checkout';
+import directoryReducer from 'src/reducers/directory';
+import checkoutReceipt from 'src/components/Checkout/Receipt/reducer';
 
 import './index.css';
 
@@ -29,6 +31,8 @@ store.addReducer('app', reducer);
 store.addReducer('user', userReducer);
 store.addReducer('cart', cartReducer);
 store.addReducer('checkout', checkoutReducer);
+store.addReducer('directory', directoryReducer);
+store.addReducer('checkoutReceipt', checkoutReceipt);
 
 store.dispatch(getUserDetails());
 


### PR DESCRIPTION
<!-- (REQUIRED) What is the nature of this PR? -->

## This PR is a:

[x] New feature
[ ] Enhancement/Optimization
[ ] Refactor
[ ] Bugfix
[ ] Test for existing code
[ ] Documentation

<!-- (REQUIRED) What does this PR change? -->

## Summary

Implement separate redux domain for checkout receipt. Connect order confirmation page component to redux.

<!-- (OPTIONAL) What other information can you provide about this PR? -->

## Additional information

I think it is better to have separate domain for each checkout steps, this will help in future to implement separate pages for each step easily if we need this. This pull request provides an example of how to organize project by feature.

<!--
Thank you for your contribution!

Before submitting this pull request, please make sure you have read our Contribution Guidelines and your PR meets our contribution standards:
https://github.com/magento-research/pwa-studio/blob/master/.github/CONTRIBUTION.md

Please fill out as much information as you can about your PR to help speed up the review process.
If your PR addresses an existing GitHub Issue, please refer to it in the title or Additional Information section to make the connection.

We may ask you for changes in your PR in order to meet the standards set in our Contribution Guidelines. PR's that do not comply with our guidelines may be closed at the maintainers' discretion.

Feel free to remove this section before creating this PR.
-->
