### PR TITLE
Disable menu toggle from header

### DIFF
--- a/packages/venia-concept/src/components/Header/header.js
+++ b/packages/venia-concept/src/components/Header/header.js
@@ -5,7 +5,6 @@ import { Link } from 'react-router-dom';
 import classify from 'src/classify';
 import Icon from 'src/components/Icon';
 import CartTrigger from './cartTrigger';
-import NavTrigger from './navTrigger';
 import defaultClasses from './header.css';
 import logo from './logo.svg';
 
@@ -39,9 +38,7 @@ class Header extends Component {
                         />
                     </Link>
                     <div className={classes.primaryActions}>
-                        <NavTrigger>
-                            <Icon name="menu" />
-                        </NavTrigger>
+                        <Icon name="menu" />
                     </div>
                     <div className={classes.secondaryActions}>
                         <button className={classes.searchTrigger}>


### PR DESCRIPTION
<!-- (REQUIRED) What is the nature of this PR? -->

## This PR is a:

[ ] New feature
[x] Enhancement/Optimization
[ ] Refactor
[ ] Bugfix
[ ] Test for existing code
[ ] Documentation

<!-- (REQUIRED) What does this PR change? -->

## Summary

Disable the menu from toggling when clicking the "hamburger" icon in header.

<!-- (OPTIONAL) What other information can you provide about this PR? -->

## Additional information

Just removed wrapping `NavTrigger` component so icon keeps its styles.

Fixes #340 

<!--
Thank you for your contribution!

Before submitting this pull request, please make sure you have read our Contribution Guidelines and your PR meets our contribution standards:
https://github.com/magento-research/pwa-studio/blob/master/.github/CONTRIBUTION.md

Please fill out as much information as you can about your PR to help speed up the review process.
If your PR addresses an existing GitHub Issue, please refer to it in the title or Additional Information section to make the connection.

We may ask you for changes in your PR in order to meet the standards set in our Contribution Guidelines. PR's that do not comply with our guidelines may be closed at the maintainers' discretion.

Feel free to remove this section before creating this PR.
-->
