### PR TITLE
Add more descriptive error msg when MAGENTO_BACKEND_URL is not set

### DIFF
--- a/packages/venia-concept/webpack.config.js
+++ b/packages/venia-concept/webpack.config.js
@@ -1,5 +1,14 @@
 require('dotenv').config();
 
+const magentoDomainVarName = 'MAGENTO_BACKEND_URL';
+const magentoDomain = process.env[magentoDomainVarName];
+if (!magentoDomain) {
+    console.error(
+        `No ${magentoDomainVarName} environment variable specified. Have you created a .env file?`
+    );
+    process.exit(1);
+}
+
 const webpack = require('webpack');
 const {
     WebpackTools: {


### PR DESCRIPTION
<!-- (REQUIRED) What is the nature of this PR? -->

## This PR is a:

[ ] New feature
[x] Enhancement/Optimization
[ ] Refactor
[ ] Bugfix
[ ] Test for existing code
[ ] Documentation

<!-- (REQUIRED) What does this PR change? -->

## Summary

Add more descriptive error message when the `MAGENTO_BACKEND_URL` environment variable is missing after trying to run `watch:venia`.

<!-- (OPTIONAL) What other information can you provide about this PR? -->

## Additional information

I used the same check that runs for the [`validate-queries`](https://github.com/magento-research/pwa-studio/blob/release/2.0/packages/venia-concept/validate-queries.js#L3-L10) task, not sure if this is still relevant after a660f6 since after that the `MAGENTO_BACKEND_URL` is not commented out by default anymore.

Fixes #342 

<!--
Thank you for your contribution!

Before submitting this pull request, please make sure you have read our Contribution Guidelines and your PR meets our contribution standards:
https://github.com/magento-research/pwa-studio/blob/master/.github/CONTRIBUTION.md

Please fill out as much information as you can about your PR to help speed up the review process.
If your PR addresses an existing GitHub Issue, please refer to it in the title or Additional Information section to make the connection.

We may ask you for changes in your PR in order to meet the standards set in our Contribution Guidelines. PR's that do not comply with our guidelines may be closed at the maintainers' discretion.

Feel free to remove this section before creating this PR.
-->
