### PR TITLE
Add new release cloud environment, add environment validation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,7 @@ common_settings:
 
   full_build: &full_build
     name: Full Build
-    command: 'cp packages/venia-concept/env.dist packages/venia-concept/.env && npm run build && npm run clean:dist'
+    command: 'cp packages/venia-concept/.env.dist packages/venia-concept/.env && npm run build && npm run clean:dist'
 
   test_result_path: &test_result_path
     path: "test-results"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,7 @@ common_settings:
 
   full_build: &full_build
     name: Full Build
-    command: 'cp packages/venia-concept/example.env packages/venia-concept/.env && npm run build && npm run clean:dist'
+    command: 'cp packages/venia-concept/env.dist packages/venia-concept/.env && npm run build && npm run clean:dist'
 
   test_result_path: &test_result_path
     path: "test-results"

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Venia and its GraphQL queries may be out of sync with the schema of your connect
 
 Generating certificates is handled by [devcert](https://github.com/davewasmer/devcert). If you're on a Linux machine make sure that `libnss3-tools` (or whatever the equivalent is) is installed on your system. Further information provided in [this section of the devcert readme](https://github.com/davewasmer/devcert#skipcertutil).
 
-**To test whether your queries are up to date, run `npm run validate:venia:gql` at project root.**
+**To test whether your queries are up to date, run `npm run validate-queries` at project root.**
 
 ## Things not to do
 

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Follow these steps to install the dependencies for all the packages in the proje
 1. Clone the repository.
 2. Navigate to the root of the repository from the command line
 3. Run `npm install`
-4. Copy `packages/venia-concept/env.dist` to `packages/venia-concept/.env`
+4. Copy `packages/venia-concept/.env.dist` to `packages/venia-concept/.env`
 5. Uncomment the line for `MAGENTO_BACKEND_URL` in `packages/venia-concept/.env`, and set `MAGENTO_BACKEND_URL` to the fully-qualified URL of a Magento store running `2.3`.
 6. On your first install, run `npm run build` from package root.
 7. To run the Venia storefront development experience, run `npm run watch:venia` from package root.
@@ -105,7 +105,7 @@ Follow these steps to install the dependencies for all the packages in the proje
 
 ### When I run the developer mode, I get validation errors
 
-Make sure you have created a `.env` file in `packages/venia-concept` which specifies variables for your local development environment. You can copy from the template `packages/venia-concept/env.dist`.
+Make sure you have created a `.env` file in `packages/venia-concept` which specifies variables for your local development environment. You can copy from the template `packages/venia-concept/.env.dist`.
 
 ### Venia queries to GraphQL produce validation errors
 

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Follow these steps to install the dependencies for all the packages in the proje
 1. Clone the repository.
 2. Navigate to the root of the repository from the command line
 3. Run `npm install`
-4. Copy `packages/venia-concept/example.env` to `packages/venia-concept/.env`
+4. Copy `packages/venia-concept/env.dist` to `packages/venia-concept/.env`
 5. Uncomment the line for `MAGENTO_BACKEND_URL` in `packages/venia-concept/.env`, and set `MAGENTO_BACKEND_URL` to the fully-qualified URL of a Magento store running `2.3`.
 6. On your first install, run `npm run build` from package root.
 7. To run the Venia storefront development experience, run `npm run watch:venia` from package root.
@@ -105,7 +105,7 @@ Follow these steps to install the dependencies for all the packages in the proje
 
 ### When I run the developer mode, I get validation errors
 
-Make sure you have created a `.env` file in `packages/venia-concept` which specifies variables for your local development environment. You can copy from the template `packages/venia-concept/example.env`.
+Make sure you have created a `.env` file in `packages/venia-concept` which specifies variables for your local development environment. You can copy from the template `packages/venia-concept/env.dist`.
 
 ### Venia queries to GraphQL produce validation errors
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "node": ">=8.0.0"
   },
   "scripts": {
-    "build": "lerna run --stream build",
+    "build": "lerna run --stream build -- -s",
     "clean:all": "lerna run clean && lerna clean --yes && rimraf ./node_modules",
     "clean:dist": "lerna run clean",
     "coveralls": "cat ./coverage/lcov.info | coveralls",
@@ -20,7 +20,7 @@
     "lint": "eslint '@(packages|scripts)/**/*.js' --ignore-pattern node_modules --ignore-pattern storybook-dist",
     "now-build": "cp packages/venia-concept/env.dist packages/venia-concept/.env && npm run -s build",
     "now-start": "UPWARD_JS_HOST=0.0.0.0 npm run -s stage:venia",
-    "prepare": "node ./scripts/update_repo_environment.js && lerna bootstrap --hoist && npm run -s build",
+    "prepare": "node ./scripts/update_repo_environment.js && lerna bootstrap --hoist",
     "prettier": "prettier --write '@(packages|scripts)/**/*.@(js|css)' '*.js'",
     "prettier:check": "prettier --list-different '@(packages|scripts)/**/*.@(js|css)' '*.js'",
     "stage:venia": "cd packages/venia-concept && npm start; cd - >/dev/null",
@@ -28,7 +28,7 @@
     "test:ci": "npm run -s test -- -i --json --outputFile=test-results.json",
     "test:debug": "node --inspect-brk node_modules/.bin/jest -i",
     "test:dev": "jest --watch",
-    "validate-queries": "lerna run --stream validate-queries",
+    "validate-queries": "lerna run validate-queries -- -s",
     "watch:all": "node scripts/watch-all.js",
     "watch:buildpack": "cd packages/pwa-buildpack && npm run -s watch; cd - >/dev/null",
     "watch:peregrine": "cd packages/peregrine && npm run -s watch; cd - >/dev/null",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "coveralls": "cat ./coverage/lcov.info | coveralls",
     "danger": "danger-ci",
     "lint": "eslint '@(packages|scripts)/**/*.js' --ignore-pattern node_modules --ignore-pattern storybook-dist",
-    "now-build": "cp packages/venia-concept/example.env packages/venia-concept/.env && npm run -s build",
+    "now-build": "cp packages/venia-concept/env.dist packages/venia-concept/.env && npm run -s build",
     "now-start": "UPWARD_JS_HOST=0.0.0.0 npm run -s stage:venia",
     "prepare": "node ./scripts/update_repo_environment.js && lerna bootstrap --hoist && npm run -s build",
     "prettier": "prettier --write '@(packages|scripts)/**/*.@(js|css)' '*.js'",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "coveralls": "cat ./coverage/lcov.info | coveralls",
     "danger": "danger-ci",
     "lint": "eslint '@(packages|scripts)/**/*.js' --ignore-pattern node_modules --ignore-pattern storybook-dist",
-    "now-build": "cp packages/venia-concept/env.dist packages/venia-concept/.env && npm run -s build",
+    "now-build": "cp packages/venia-concept/.env.dist packages/venia-concept/.env && npm run -s build",
     "now-start": "UPWARD_JS_HOST=0.0.0.0 npm run -s stage:venia",
     "prepare": "node ./scripts/update_repo_environment.js && lerna bootstrap --hoist",
     "prettier": "prettier --write '@(packages|scripts)/**/*.@(js|css)' '*.js'",

--- a/packages/peregrine/src/List/__tests__/items.spec.js
+++ b/packages/peregrine/src/List/__tests__/items.spec.js
@@ -10,9 +10,7 @@ const items = [
     {
         id: '001',
         name: 'Test Product 1',
-        small_image: {
-            path: '/test/product/1.png'
-        },
+        small_image: '/test/product/1.png',
         price: {
             regularPrice: {
                 amount: {
@@ -24,9 +22,7 @@ const items = [
     {
         id: '002',
         name: 'Test Product 2',
-        small_image: {
-            path: '/test/product/2.png'
-        },
+        small_image: '/test/product/2.png',
         price: {
             regularPrice: {
                 amount: {

--- a/packages/peregrine/src/List/__tests__/list.spec.js
+++ b/packages/peregrine/src/List/__tests__/list.spec.js
@@ -14,9 +14,7 @@ const items = [
     {
         id: '001',
         name: 'Test Product 1',
-        small_image: {
-            path: '/test/product/1.png'
-        },
+        small_image: '/test/product/1.png',
         price: {
             regularPrice: {
                 amount: {
@@ -28,9 +26,7 @@ const items = [
     {
         id: '002',
         name: 'Test Product 2',
-        small_image: {
-            path: '/test/product/2.png'
-        },
+        small_image: '/test/product/2.png',
         price: {
             regularPrice: {
                 amount: {

--- a/packages/pwa-buildpack/src/WebpackTools/plugins/UpwardPlugin.js
+++ b/packages/pwa-buildpack/src/WebpackTools/plugins/UpwardPlugin.js
@@ -9,7 +9,8 @@ const upward = require('@magento/upward-js');
 const httpsAgent = new https.Agent({ rejectUnauthorized: false });
 
 class UpwardPlugin {
-    constructor(devServer, upwardPath) {
+    constructor(devServer, env, upwardPath) {
+        this.env = env;
         this.upwardPath = upwardPath;
         // Compose `after` function if something else has defined it.
         const oldAfter = devServer.after;
@@ -92,7 +93,11 @@ class UpwardPlugin {
             }
         };
 
-        this.middleware = await upward.middleware(this.upwardPath, io);
+        this.middleware = await upward.middleware(
+            this.upwardPath,
+            this.env,
+            io
+        );
     }
     async getCompiler() {
         if (this.compiler) {

--- a/packages/pwa-buildpack/src/WebpackTools/plugins/__tests__/UpwardPlugin.spec.js
+++ b/packages/pwa-buildpack/src/WebpackTools/plugins/__tests__/UpwardPlugin.spec.js
@@ -9,7 +9,7 @@ test('creates a devServer.after function if it does not exist', () => {
     const app = {
         use: jest.fn()
     };
-    new UpwardPlugin(devServer);
+    new UpwardPlugin(devServer, process.env);
     expect(devServer.after).toBeInstanceOf(Function);
     devServer.after(app);
     expect(app.use).toHaveBeenCalledWith(expect.any(Function));
@@ -21,7 +21,7 @@ test('composes with an existing devServer.after function', () => {
     const app = {
         use: jest.fn()
     };
-    new UpwardPlugin(devServer);
+    new UpwardPlugin(devServer, process.env);
     expect(devServer.after).not.toBe(after);
     devServer.after(app);
     expect(app.use).toHaveBeenCalledWith(expect.any(Function));
@@ -41,11 +41,15 @@ test('applies to a Webpack compiler and resolves any existing devServer requests
 
     upward.middleware.mockResolvedValueOnce(upwardHandler);
 
-    const noRequestsWaiting = new UpwardPlugin({});
+    const noRequestsWaiting = new UpwardPlugin({}, process.env);
     noRequestsWaiting.apply(compiler);
     expect(noRequestsWaiting.compiler).toBe(compiler);
 
-    const hasRequestsWaiting = new UpwardPlugin(devServer, 'path/to/upward');
+    const hasRequestsWaiting = new UpwardPlugin(
+        devServer,
+        process.env,
+        'path/to/upward'
+    );
     devServer.after(app);
     const handler = app.use.mock.calls[0][0];
 
@@ -63,7 +67,8 @@ test('applies to a Webpack compiler and resolves any existing devServer requests
         expect.objectContaining({
             readFile: expect.any(Function),
             networkFetch: expect.any(Function)
-        })
+        }),
+        process.env
     );
     expect(upwardHandler).toHaveBeenCalledWith(req, res, next);
 });
@@ -74,7 +79,7 @@ test('shares compiler promise', async () => {
     const upwardHandler = jest.fn();
 
     upward.middleware.mockResolvedValueOnce(upwardHandler);
-    const plugin = new UpwardPlugin(devServer, 'path/to/upward');
+    const plugin = new UpwardPlugin(devServer, process.env, 'path/to/upward');
 
     const promises = [plugin.getCompiler(), plugin.getCompiler()];
 
@@ -97,7 +102,7 @@ test('shares middleware promise so as not to create multiple middlewares', async
     const upwardHandler = jest.fn();
 
     upward.middleware.mockResolvedValueOnce(upwardHandler);
-    const plugin = new UpwardPlugin(devServer, 'path/to/upward');
+    const plugin = new UpwardPlugin(devServer, process.env, 'path/to/upward');
     devServer.after(app);
     const handler = app.use.mock.calls[0][0];
 
@@ -130,7 +135,7 @@ test('supplies a dev-mode IOAdapter with webpack fs integration', async () => {
     upward.middleware.mockResolvedValueOnce(() => {});
     upward.IOAdapter.default.mockReturnValueOnce(defaultIO);
 
-    const plugin = new UpwardPlugin(devServer);
+    const plugin = new UpwardPlugin(devServer, process.env);
     plugin.apply(compiler);
     devServer.after(app);
     const handler = app.use.mock.calls[0][0];
@@ -197,7 +202,7 @@ test('dev-mode IOAdapter uses fetch', async () => {
 
     upward.middleware.mockResolvedValueOnce(() => {});
 
-    const plugin = new UpwardPlugin(devServer);
+    const plugin = new UpwardPlugin(devServer, process.env);
     plugin.apply({});
     devServer.after(app);
     const handler = app.use.mock.calls[0][0];
@@ -225,7 +230,7 @@ test('dev-mode IOAdapter can fetch unsecure URLs', async () => {
 
     upward.middleware.mockResolvedValueOnce(() => {});
 
-    const plugin = new UpwardPlugin(devServer);
+    const plugin = new UpwardPlugin(devServer, process.env);
     plugin.apply({});
     devServer.after(app);
     const handler = app.use.mock.calls[0][0];

--- a/packages/pwa-buildpack/src/WebpackTools/plugins/__tests__/UpwardPlugin.spec.js
+++ b/packages/pwa-buildpack/src/WebpackTools/plugins/__tests__/UpwardPlugin.spec.js
@@ -64,11 +64,11 @@ test('applies to a Webpack compiler and resolves any existing devServer requests
     expect(upward.IOAdapter.default).toHaveBeenCalledWith('path/to/upward');
     expect(upward.middleware).toHaveBeenCalledWith(
         'path/to/upward',
+        process.env,
         expect.objectContaining({
             readFile: expect.any(Function),
             networkFetch: expect.any(Function)
-        }),
-        process.env
+        })
     );
     expect(upwardHandler).toHaveBeenCalledWith(req, res, next);
 });
@@ -142,7 +142,7 @@ test('supplies a dev-mode IOAdapter with webpack fs integration', async () => {
     handler();
     await plugin.middlewarePromise;
 
-    const io = upward.middleware.mock.calls[0][1];
+    const io = upward.middleware.mock.calls[0][2];
 
     compiler.outputFileSystem.readFileSync.mockImplementationOnce(() => {
         return 'from output file system';
@@ -209,7 +209,7 @@ test('dev-mode IOAdapter uses fetch', async () => {
     handler();
     await plugin.middlewarePromise;
 
-    const io = upward.middleware.mock.calls[0][1];
+    const io = upward.middleware.mock.calls[0][2];
 
     io.networkFetch('https://example.com', { method: 'POST' });
 
@@ -237,7 +237,7 @@ test('dev-mode IOAdapter can fetch unsecure URLs', async () => {
     handler();
     await plugin.middlewarePromise;
 
-    const io = upward.middleware.mock.calls[0][1];
+    const io = upward.middleware.mock.calls[0][2];
 
     io.networkFetch('http://example.com', { method: 'POST' });
 

--- a/packages/upward-js/bin/server
+++ b/packages/upward-js/bin/server
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 require('dotenv').config();
 
-const config = require('../lib/envToConfig')();
+const config = require('../lib/envToConfig')(process.env);
 
 require('../lib/createUpwardServer.js')(config).catch(e => {
     console.error(e.stack);

--- a/packages/upward-js/lib/__tests__/envToConfig.test.js
+++ b/packages/upward-js/lib/__tests__/envToConfig.test.js
@@ -1,13 +1,14 @@
 const envToConfig = require('../envToConfig');
 
 test('converts namespaced env vars to config object and casts values', () => {
-    Object.assign(process.env, {
-        UPWARD_JS_ONE_TWO: 'false',
-        UPWARD_JS_THREE_FOUR: 'trUE',
-        UPWARD_JS_FIVE_SIX_SEVEN: '9.4',
-        UPWARD_JS_EIGHTNINE: 'eight and nine'
-    });
-    expect(envToConfig()).toEqual({
+    expect(
+        envToConfig({
+            UPWARD_JS_ONE_TWO: 'false',
+            UPWARD_JS_THREE_FOUR: 'trUE',
+            UPWARD_JS_FIVE_SIX_SEVEN: '9.4',
+            UPWARD_JS_EIGHTNINE: 'eight and nine'
+        })
+    ).toEqual({
         oneTwo: false,
         threeFour: true,
         fiveSixSeven: 9.4,

--- a/packages/upward-js/lib/createUpwardServer.js
+++ b/packages/upward-js/lib/createUpwardServer.js
@@ -38,14 +38,15 @@ async function createUpwardServer({
     host = '0.0.0.0',
     https,
     logUrl = false,
-    upwardPath
+    upwardPath,
+    env = process.env
 }) {
     if (!upwardPath) {
         throw new Error(`upwardPath is required`);
     }
     const app = express();
-    const upward = await middleware(resolve(upwardPath));
-    if (process.env.NODE_ENV === 'production') {
+    const upward = await middleware(resolve(upwardPath), env);
+    if (env.NODE_ENV === 'production') {
         app.use(morgan('combined'));
         app.use(upward);
     } else {

--- a/packages/upward-js/lib/envToConfig.js
+++ b/packages/upward-js/lib/envToConfig.js
@@ -16,8 +16,8 @@ function castValue(value) {
 
 const envPrefix = 'UPWARD_JS_';
 // Parse and camelcast all environment variables beginning with a prefix.
-function envToConfig() {
-    return Object.entries(process.env).reduce((cfg, [key, value]) => {
+function envToConfig(env) {
+    return Object.entries(env).reduce((cfg, [key, value]) => {
         if (key.startsWith(envPrefix)) {
             const camelCased = key
                 .slice(envPrefix.length)
@@ -32,7 +32,6 @@ function envToConfig() {
 module.exports = envToConfig;
 
 /**
- * const config = envToConfig('UPWARD_JS_');
  *
  * UPWARD_JS_BIND_LOCAL=true \
  * UPWARD_JS_FOO=FALSE \

--- a/packages/upward-js/lib/middleware.js
+++ b/packages/upward-js/lib/middleware.js
@@ -5,7 +5,8 @@ const IOAdapter = require('./IOAdapter');
 const buildResponse = require('./buildResponse');
 
 class UpwardMiddleware {
-    constructor(upwardPath, io) {
+    constructor(upwardPath, env, io) {
+        this.env = env;
         this.upwardPath = upwardPath;
         debug(`created for path ${upwardPath}`);
         this.io = io;
@@ -35,7 +36,7 @@ class UpwardMiddleware {
             try {
                 response = await buildResponse(
                     this.io,
-                    process.env,
+                    this.env,
                     this.definition,
                     req
                 );
@@ -86,9 +87,10 @@ class UpwardMiddleware {
 
 async function upwardJSMiddlewareFactory(
     upwardPath,
+    env,
     io = IOAdapter.default(upwardPath)
 ) {
-    const middleware = new UpwardMiddleware(upwardPath, io);
+    const middleware = new UpwardMiddleware(upwardPath, env, io);
     await middleware.load();
     return middleware.getHandler();
 }

--- a/packages/venia-concept/.env.dist
+++ b/packages/venia-concept/.env.dist
@@ -1,4 +1,4 @@
-########## env.dist ########################################################
+########## .env.dist ########################################################
 #
 #   This file is an example of how to configure Magento PWA Studio at
 #   development time and runtime. Use these environment variables for any

--- a/packages/venia-concept/.env.dist
+++ b/packages/venia-concept/.env.dist
@@ -1,4 +1,4 @@
-########## example.env ########################################################
+########## env.dist ########################################################
 #
 #   This file is an example of how to configure Magento PWA Studio at
 #   development time and runtime. Use these environment variables for any
@@ -15,7 +15,7 @@
 #
 #   Connect to an instance of Magento 2.3 by specifying its public
 #   domain name. **REQUIRED.** Example:
-MAGENTO_BACKEND_URL="https://master-7rqtwti-dpfibs5yviagi.us-3.magentosite.cloud/"
+MAGENTO_BACKEND_URL="https://release-utkfd3a-dpfibs5yviagi.us-3.magentosite.cloud/"
 #
 #   Use a particular website code when making API calls. Defaults to 'base',
 #   but for your PWA to act as a different "website" in the Magento admin,

--- a/packages/venia-concept/package.json
+++ b/packages/venia-concept/package.json
@@ -12,12 +12,9 @@
   "bugs": {
     "url": "https://github.com/magento-research/pwa-studio/issues"
   },
-  "config": {
-    "serviceWorkerFileName": "sw.js"
-  },
   "homepage": "https://github.com/magento-research/pwa-studio/tree/master/packages/venia-concept#readme",
   "scripts": {
-    "build": "webpack --color --progress --profile --env.phase production",
+    "build": "npm run -s validate-queries && webpack --color --progress --profile --env.phase production",
     "clean": "rimraf dist",
     "start": "node server.js",
     "start:debug": "node --inspect-brk ./node_modules/.bin/webpack-dev-server --progress --color --env.phase development",
@@ -26,7 +23,9 @@
   },
   "dependencies": {
     "@magento/pwa-buildpack": "^2.0.0-rc2.0.5",
-    "@magento/upward-js": "^2.0.0-rc2.0.5"
+    "@magento/upward-js": "^2.0.0-rc2.0.5",
+    "chalk": "^2.4.1",
+    "envalid": "^4.1.4"
   },
   "devDependencies": {
     "@magento/peregrine": "^2.0.0-rc2.0.5",

--- a/packages/venia-concept/server.js
+++ b/packages/venia-concept/server.js
@@ -1,5 +1,5 @@
-validEnv.NODE_TLS_REJECT_UNAUTHORIZED = 0;
-const validEnv = require('./validate-environment')(validEnv);
+process.env.NODE_TLS_REJECT_UNAUTHORIZED = 0;
+const validEnv = require('./validate-environment')(process.env);
 const {
     Utilities: { configureHost }
 } = require('@magento/pwa-buildpack');
@@ -11,7 +11,8 @@ async function serve() {
             bindLocal: true,
             logUrl: true
         },
-        envToConfig()
+        envToConfig(validEnv),
+        { env: validEnv }
     );
 
     if (!config.host) {

--- a/packages/venia-concept/server.js
+++ b/packages/venia-concept/server.js
@@ -1,5 +1,5 @@
-process.env.NODE_TLS_REJECT_UNAUTHORIZED = 0;
-require('dotenv').config();
+validEnv.NODE_TLS_REJECT_UNAUTHORIZED = 0;
+const validEnv = require('./validate-environment')(validEnv);
 const {
     Utilities: { configureHost }
 } = require('@magento/pwa-buildpack');
@@ -17,11 +17,11 @@ async function serve() {
     if (!config.host) {
         try {
             const { hostname, ports, ssl } = await configureHost({
-                subdomain: process.env.MAGENTO_BUILDPACK_SECURE_HOST_SUBDOMAIN,
+                subdomain: validEnv.MAGENTO_BUILDPACK_SECURE_HOST_SUBDOMAIN,
                 exactDomain:
-                    process.env.MAGENTO_BUILDPACK_SECURE_HOST_EXACT_DOMAIN,
-                addUniqueHash: !!process.env
-                    .MAGENTO_BUILDPACK_SECURE_HOST_ADD_UNIQUE_HASH
+                    validEnv.MAGENTO_BUILDPACK_SECURE_HOST_EXACT_DOMAIN,
+                addUniqueHash:
+                    validEnv.MAGENTO_BUILDPACK_SECURE_HOST_ADD_UNIQUE_HASH
             });
             config.host = hostname;
             config.https = ssl;

--- a/packages/venia-concept/src/RootComponents/Category/category.js
+++ b/packages/venia-concept/src/RootComponents/Category/category.js
@@ -17,9 +17,7 @@ const categoryQuery = gql`
                 items {
                     id
                     name
-                    small_image {
-                        path
-                    }
+                    small_image
                     url_key
                     price {
                         regularPrice {

--- a/packages/venia-concept/src/components/Gallery/__tests__/gallery.spec.js
+++ b/packages/venia-concept/src/components/Gallery/__tests__/gallery.spec.js
@@ -11,9 +11,7 @@ const items = [
     {
         id: 1,
         name: 'Test Product 1',
-        small_image: {
-            path: '/test/product/1.png'
-        },
+        small_image: '/test/product/1.png',
         price: {
             regularPrice: {
                 amount: {
@@ -26,9 +24,7 @@ const items = [
     {
         id: 2,
         name: 'Test Product 2',
-        small_image: {
-            path: '/test/product/2.png'
-        },
+        small_image: '/test/product/2.png',
         price: {
             regularPrice: {
                 amount: {

--- a/packages/venia-concept/src/components/Gallery/__tests__/item.spec.js
+++ b/packages/venia-concept/src/components/Gallery/__tests__/item.spec.js
@@ -25,9 +25,7 @@ const classes = {
 const validItem = {
     id: 1,
     name: 'Test Product',
-    small_image: {
-        path: '/foo/bar/pic.png'
-    },
+    small_image: '/foo/bar/pic.png',
     url_key: 'strive-shoulder-pack',
     price: {
         regularPrice: {

--- a/packages/venia-concept/src/components/Gallery/__tests__/items.spec.js
+++ b/packages/venia-concept/src/components/Gallery/__tests__/items.spec.js
@@ -10,9 +10,7 @@ const items = [
     {
         id: 1,
         name: 'Test Product 1',
-        small_image: {
-            path: '/test/product/1.png'
-        },
+        small_image: '/test/product/1.png',
         price: {
             regularPrice: {
                 amount: {
@@ -24,9 +22,7 @@ const items = [
     {
         id: 2,
         name: 'Test Product 2',
-        small_image: {
-            path: '/test/product/2.png'
-        },
+        small_image: '/test/product/2.png',
         price: {
             regularPrice: {
                 amount: {

--- a/packages/venia-concept/src/components/Gallery/gallery.js
+++ b/packages/venia-concept/src/components/Gallery/gallery.js
@@ -19,9 +19,7 @@ class Gallery extends Component {
             shape({
                 id: number.isRequired,
                 name: string.isRequired,
-                small_image: shape({
-                    path: string.isRequired
-                }).isRequired,
+                small_image: string.isRequired,
                 price: shape({
                     regularPrice: shape({
                         amount: shape({

--- a/packages/venia-concept/src/components/Gallery/item.js
+++ b/packages/venia-concept/src/components/Gallery/item.js
@@ -40,9 +40,7 @@ class GalleryItem extends Component {
         item: shape({
             id: number.isRequired,
             name: string.isRequired,
-            small_image: shape({
-                path: string.isRequired
-            }).isRequired,
+            small_image: string.isRequired,
             url_key: string.isRequired,
             price: shape({
                 regularPrice: shape({
@@ -140,7 +138,7 @@ class GalleryItem extends Component {
         return (
             <img
                 className={className}
-                src={makeProductMediaPath(small_image.path)}
+                src={makeProductMediaPath(small_image)}
                 alt={name}
                 width={imageWidth}
                 height={imageHeight}

--- a/packages/venia-concept/src/components/Gallery/items.js
+++ b/packages/venia-concept/src/components/Gallery/items.js
@@ -26,9 +26,7 @@ class GalleryItems extends Component {
             shape({
                 id: number.isRequired,
                 name: string.isRequired,
-                small_image: shape({
-                    path: string.isRequired
-                }).isRequired,
+                small_image: string.isRequired,
                 price: shape({
                     regularPrice: shape({
                         amount: shape({

--- a/packages/venia-concept/validate-environment.js
+++ b/packages/venia-concept/validate-environment.js
@@ -1,0 +1,94 @@
+function validateEnvironment(env) {
+    const { readFileSync } = require('fs');
+    const path = require('path');
+    const dotenv = require('dotenv');
+    const chalk = require('chalk');
+
+    let parsedEnv;
+    const envPath = path.join(__dirname, '.env');
+    try {
+        parsedEnv = dotenv.parse(readFileSync(envPath));
+        console.log(
+            chalk.green(
+                `Using environment variables from ${chalk.greenBright('.env')}`
+            )
+        );
+        if (env.DEBUG || env.NODE_DEBUG) {
+            console.log(
+                '\n  ' +
+                    require('util')
+                        .inspect(parsedEnv, {
+                            colors: true,
+                            compact: false
+                        })
+                        .replace(/\s*[\{\}]\s*/gm, '')
+                        .replace(/,\n\s+/gm, '\n  ') +
+                    '\n'
+            );
+        }
+    } catch (e) {
+        if (e.code === 'ENOENT') {
+            console.log(
+                chalk.redBright(
+                    `\nNo .env file in ${__dirname}\n\tYou may need to copy 'env.dist' to '.env' to begin, or create your own '.env' file manually.`
+                )
+            );
+        } else {
+            console.log(
+                chalk.redBright(`\nCould not retrieve and parse ${envPath}.`, e)
+            );
+        }
+    }
+
+    const envalid = require('envalid');
+    const { str, bool, url } = envalid;
+
+    return envalid.cleanEnv(env, {
+        MAGENTO_BACKEND_URL: url({
+            desc: 'Public base URL of of Magento 2.3 instance.',
+            example: 'https://magento2.vagrant65'
+        }),
+        SERVICE_WORKER_FILE_NAME: str({
+            desc:
+                'Filename to use when autogenerating a service worker to be served at root.',
+            example: 'sw.js',
+            default: 'sw.js'
+        }),
+        MAGENTO_BUILDPACK_PROVIDE_SECURE_HOST: bool({
+            desc:
+                'On first run, create a secure, unique hostname and generate a trusted SSL certificate.',
+            default: true
+        }),
+        MAGENTO_BUILDPACK_SECURE_HOST_AND_UNIQUE_HASH: bool({
+            desc:
+                'Add a unique hash based on filesystem location to the unique hostname. No effect if MAGENTO_BUILDPACK_PROVIDE_SECURE_HOST is false.',
+            default: true
+        }),
+        ENABLE_SERVICE_WORKER_DEBUGGING: bool({
+            desc:
+                'Use a service worker in developer mode (PWADevServer), which are disabled in dev mode normally to simplify cache. Good for debugging.',
+            default: false
+        }),
+        UPWARD_JS_UPWARD_PATH: str({
+            desc:
+                'UPWARD configuration file to use for the PWADevServer and the "stage:venia" sample server.',
+            default: 'venia-upward.yml'
+        }),
+        UPWARD_JS_BIND_LOCAL: bool({
+            desc:
+                'Upon launching the staging server, automatically attach to a local port and listen.',
+            default: true
+        }),
+        UPWARD_JS_LOG_URL: bool({
+            desc:
+                'Tell the upward-js prod server to log the bound URL to stdout. Useful in testing and discovery scenarios, but may be disabled in production.',
+            default: true
+        })
+    });
+}
+
+module.exports = validateEnvironment;
+
+if (module === require.main) {
+    validateEnvironment(prcoess.env);
+}

--- a/packages/venia-concept/validate-environment.js
+++ b/packages/venia-concept/validate-environment.js
@@ -90,5 +90,5 @@ function validateEnvironment(env) {
 module.exports = validateEnvironment;
 
 if (module === require.main) {
-    validateEnvironment(prcoess.env);
+    validateEnvironment(process.env);
 }

--- a/packages/venia-concept/validate-environment.js
+++ b/packages/venia-concept/validate-environment.js
@@ -30,7 +30,7 @@ function validateEnvironment(env) {
         if (e.code === 'ENOENT') {
             console.log(
                 chalk.redBright(
-                    `\nNo .env file in ${__dirname}\n\tYou may need to copy 'env.dist' to '.env' to begin, or create your own '.env' file manually.`
+                    `\nNo .env file in ${__dirname}\n\tYou may need to copy '.env.dist' to '.env' to begin, or create your own '.env' file manually.`
                 )
             );
         } else {

--- a/packages/venia-concept/validate-queries.js
+++ b/packages/venia-concept/validate-queries.js
@@ -1,11 +1,11 @@
-require('dotenv').config();
 process.env.NODE_TLS_REJECT_UNAUTHORIZED = 0;
+const validEnv = require('./validate-environment')(process.env);
+
 const magentoDomainVarName = 'MAGENTO_BACKEND_URL';
-const magentoDomain = process.env[magentoDomainVarName];
+const magentoDomain = validEnv[magentoDomainVarName];
 if (!magentoDomain) {
-    console.error(
-        `No ${magentoDomainVarName} environment variable specified. Have you created a .env file?`
-    );
+    console.error(`No ${magentoDomainVarName} environment variable specified.`);
+
     process.exit(1);
 }
 

--- a/packages/venia-concept/webpack.config.js
+++ b/packages/venia-concept/webpack.config.js
@@ -157,8 +157,8 @@ module.exports = async function(passedEnv) {
             new webpack.HotModuleReplacementPlugin(),
             new UpwardPlugin(
                 config.devServer,
-                path.resolve(__dirname, validEnv.UPWARD_JS_UPWARD_PATH),
-                validEnv
+                validEnv,
+                path.resolve(__dirname, validEnv.UPWARD_JS_UPWARD_PATH)
             )
         );
     } else if (phase === 'production') {

--- a/packages/venia-concept/webpack.config.js
+++ b/packages/venia-concept/webpack.config.js
@@ -1,4 +1,4 @@
-require('dotenv').config();
+const validEnv = require('./validate-environment')(process.env);
 
 const webpack = require('webpack');
 const {
@@ -12,7 +12,6 @@ const {
 } = require('@magento/pwa-buildpack');
 const path = require('path');
 
-const pkg = require(path.resolve(__dirname, 'package.json'));
 const UglifyPlugin = require('uglifyjs-webpack-plugin');
 const configureBabel = require('./babel.config.js');
 
@@ -31,17 +30,15 @@ const libs = [
     'redux'
 ];
 
-module.exports = async function(env) {
-    const { phase } = env;
+module.exports = async function(passedEnv) {
+    const { phase } = passedEnv;
 
     const babelOptions = configureBabel(phase);
 
     const enableServiceWorkerDebugging =
-        Number(process.env.ENABLE_SERVICE_WORKER_DEBUGGING) === 1;
+        validEnv.ENABLE_SERVICE_WORKER_DEBUGGING;
 
-    const serviceWorkerFileName =
-        process.env.SERVICE_WORKER_FILE_NAME ||
-        pkg.config.serviceWorkerFileName;
+    const serviceWorkerFileName = validEnv.SERVICE_WORKER_FILE_NAME;
 
     const config = {
         context: __dirname, // Node global for the running script's directory
@@ -118,11 +115,11 @@ module.exports = async function(env) {
                  * https://github.com/magento/graphql-ce/issues/88
                  */
                 'process.env.MAGENTO_BACKEND_PRODUCT_MEDIA_PATH': JSON.stringify(
-                    process.env.MAGENTO_BACKEND_PRODUCT_MEDIA_PATH
+                    validEnv.MAGENTO_BACKEND_PRODUCT_MEDIA_PATH
                 )
             }),
             new ServiceWorkerPlugin({
-                env,
+                env: Object.assign({}, validEnv, passedEnv),
                 enableServiceWorkerDebugging,
                 serviceWorkerFileName,
                 paths: themePaths
@@ -138,14 +135,13 @@ module.exports = async function(env) {
                 queryDirs: [path.resolve(themePaths.src, 'queries')]
             }
         };
-        const provideHost = !!process.env.MAGENTO_BUILDPACK_PROVIDE_SECURE_HOST;
+        const provideHost = !!validEnv.MAGENTO_BUILDPACK_PROVIDE_SECURE_HOST;
         if (provideHost) {
             devServerConfig.provideSecureHost = {
-                subdomain: process.env.MAGENTO_BUILDPACK_SECURE_HOST_SUBDOMAIN,
+                subdomain: validEnv.MAGENTO_BUILDPACK_SECURE_HOST_SUBDOMAIN,
                 exactDomain:
-                    process.env.MAGENTO_BUILDPACK_SECURE_HOST_EXACT_DOMAIN,
-                addUniqueHash: !!process.env
-                    .MAGENTO_BUILDPACK_SECURE_HOST_ADD_UNIQUE_HASH
+                    validEnv.MAGENTO_BUILDPACK_SECURE_HOST_EXACT_DOMAIN,
+                addUniqueHash: !!validEnv.MAGENTO_BUILDPACK_SECURE_HOST_ADD_UNIQUE_HASH
             };
         }
         config.devServer = await PWADevServer.configure(devServerConfig);
@@ -161,7 +157,8 @@ module.exports = async function(env) {
             new webpack.HotModuleReplacementPlugin(),
             new UpwardPlugin(
                 config.devServer,
-                path.resolve(__dirname, 'venia-upward.yml')
+                path.resolve(__dirname, validEnv.UPWARD_JS_UPWARD_PATH),
+                validEnv
             )
         );
     } else if (phase === 'production') {

--- a/pwa-devdocs/src/pwa-buildpack/troubleshooting/index.md
+++ b/pwa-devdocs/src/pwa-buildpack/troubleshooting/index.md
@@ -27,7 +27,7 @@ Paste the result console output into the issue. Thank you!
 
 **Validation errors when running developer mode**{:#validation-errors}
 
-Make sure you copied over the `example.env` file into a new `.env` file in the `packages/venia-concept` directory.
+Make sure you copied over the `env.dist` file into a new `.env` file in the `packages/venia-concept` directory.
 This file should specify variables for your local development environment.
 
 **Venia queries to GraphQL produce validation errors**{:#graphql-validation-errors}

--- a/pwa-devdocs/src/pwa-buildpack/troubleshooting/index.md
+++ b/pwa-devdocs/src/pwa-buildpack/troubleshooting/index.md
@@ -38,7 +38,7 @@ Make sure your Magento instance is up to date with the latest from Magento 2.3 d
 To test whether your queries are up to date, run the following command in the project root:
 
 ``` sh
-npm run validate:venia:gql
+npm run validate-queries
 ```
 
 **Browser displays "Cannot proxy to " error and the console displays `ENOTFOUND`**{:#cannot-proxy}

--- a/pwa-devdocs/src/pwa-buildpack/troubleshooting/index.md
+++ b/pwa-devdocs/src/pwa-buildpack/troubleshooting/index.md
@@ -27,7 +27,7 @@ Paste the result console output into the issue. Thank you!
 
 **Validation errors when running developer mode**{:#validation-errors}
 
-Make sure you copied over the `env.dist` file into a new `.env` file in the `packages/venia-concept` directory.
+Make sure you copied over the `.env.dist` file into a new `.env` file in the `packages/venia-concept` directory.
 This file should specify variables for your local development environment.
 
 **Venia queries to GraphQL produce validation errors**{:#graphql-validation-errors}

--- a/pwa-devdocs/src/venia-pwa-concept/setup/index.md
+++ b/pwa-devdocs/src/venia-pwa-concept/setup/index.md
@@ -157,7 +157,7 @@ Under the `packages/venia-concept` directory, copy `.env.dist` into a new `.env`
 cd /Users/magedev/pwa-studio/packages/venia-concept
 ```
 ``` sh
-cp env.dist .env
+cp .env.dist .env
 ```
 
 In the `.env` file set the value of `MAGENTO_BACKEND_URL` to the URL of your Magento development store.

--- a/pwa-devdocs/src/venia-pwa-concept/setup/index.md
+++ b/pwa-devdocs/src/venia-pwa-concept/setup/index.md
@@ -157,7 +157,7 @@ Under the `packages/venia-concept` directory, copy `.env.dist` into a new `.env`
 cd /Users/magedev/pwa-studio/packages/venia-concept
 ```
 ``` sh
-cp example.env .env
+cp env.dist .env
 ```
 
 In the `.env` file set the value of `MAGENTO_BACKEND_URL` to the URL of your Magento development store.


### PR DESCRIPTION
<!-- (REQUIRED) What is the nature of this PR? -->

## This PR is a:

[ ] New feature
[x] Enhancement/Optimization
[ ] Refactor
[ ] Bugfix
[x] Test for existing code
[ ] Documentation

<!-- (REQUIRED) What does this PR change? -->

## Summary

When this pull request is merged, it will:

- Rename `example.env` to `env.dist` following convention (closing #384)
- Replace the default `MAGENTO_BACKEND_URL` value in `env.dist` with the new "release" cloud environment: https://release-utkfd3a-dpfibs5yviagi.us-3.magentosite.cloud/
- Add more environment variable validation, so that new users of the project see clearer instructions for enabling their development environment after install
- Switching to a schema-validated environment object required that the UpwardPlugin and `upward-js` no longer use `process.env` directly
- Reverted parts of #318 and restored the simple `small_image: String` GraphQL query structure to compatible with 2.3.

## Additional information

I had to revert the `small_image` schema change because it turns out that the change to the schema has not made it into Magento 2 `2.3.0-release`. We are no longer developing on Magento 2 `2.3-develop`.