### PR TITLE
Add tests for static part of purchase details page

### DIFF
--- a/packages/venia-concept/__mocks__/@magento/peregrine.js
+++ b/packages/venia-concept/__mocks__/@magento/peregrine.js
@@ -1,15 +1,17 @@
 import React from 'react';
 import { BrowserPersistence } from './util/simplePersistence';
 
-export const mockRequest = jest.fn();
+const peregrine = jest.requireActual('../../../peregrine/src');
 
-export const RestApi = {
+const mockRequest = jest.fn();
+
+const RestApi = {
     Magento2: {
         request: mockRequest
     }
 };
 
-export const Util = {
+const Util = {
     BrowserPersistence: BrowserPersistence
 };
 
@@ -18,4 +20,12 @@ export const Util = {
  * has browser-specific functionality and cannot
  * currently by rendered in the test environment
  */
-export const Price = () => <div />;
+const Price = () => <div />;
+
+module.exports = {
+    ...peregrine,
+    mockRequest,
+    RestApi,
+    Util,
+    Price
+};

--- a/packages/venia-concept/__mocks__/fileMock.js
+++ b/packages/venia-concept/__mocks__/fileMock.js
@@ -1,0 +1,1 @@
+module.exports = 'test-file-stub';

--- a/packages/venia-concept/jest.config.js
+++ b/packages/venia-concept/jest.config.js
@@ -5,6 +5,7 @@ module.exports = {
     browser: true,
     testURL: 'https://localhost/',
     moduleNameMapper: {
+        '\\.(jpg|jpeg|png)$': '<rootDir>/__mocks__/fileMock.js',
         '\\.css$': 'identity-obj-proxy',
         // Mirrors webpack alias to resolve from 'src'
         '^src/(.+)': '<rootDir>/src/$1',

--- a/packages/venia-concept/src/actions/purchaseDetails/__tests__/actions.spec.js
+++ b/packages/venia-concept/src/actions/purchaseDetails/__tests__/actions.spec.js
@@ -1,0 +1,25 @@
+import actions from '../actions';
+
+test('purchaseDetails.request.toString() returns the proper action type', () => {
+    expect(actions.request.toString()).toBe('PURCHASE_DETAILS/REQUEST');
+});
+
+test('purchaseDetails.request() returns a proper action object', () => {
+    const orderId = 1;
+    expect(actions.request({ orderId })).toEqual({
+        type: 'PURCHASE_DETAILS/REQUEST',
+        payload: { orderId }
+    });
+});
+
+test('purchaseDetails.receive.toString() returns the proper action type', () => {
+    expect(actions.receive.toString()).toBe('PURCHASE_DETAILS/RECEIVE');
+});
+
+test('purchaseDetails.receive() returns a proper action object', () => {
+    const order = {};
+    expect(actions.receive({ order })).toEqual({
+        type: 'PURCHASE_DETAILS/RECEIVE',
+        payload: { order }
+    });
+});

--- a/packages/venia-concept/src/actions/purchaseDetails/__tests__/asyncActions.spec.js
+++ b/packages/venia-concept/src/actions/purchaseDetails/__tests__/asyncActions.spec.js
@@ -1,0 +1,17 @@
+import { dispatch, getState } from 'src/store';
+import { fetchOrderDetails } from '../asyncActions';
+
+//TODO: write the rest part of the test when fetching async action will be in working condition(currently it's mock)
+jest.mock('src/store');
+
+const thunkArgs = [dispatch, getState];
+
+test('fetchOrderDetails() to return a thunk', () => {
+    expect(fetchOrderDetails()).toBeInstanceOf(Function);
+});
+
+test('fetchOrderDetails thunk returns undefined', async () => {
+    const thunk = fetchOrderDetails();
+
+    await expect(thunk(...thunkArgs)).resolves.toBeUndefined();
+});

--- a/packages/venia-concept/src/components/PurchaseDetailsPage/OrderItem/ButtonGroup/__tests__/buttonGroup.spec.js
+++ b/packages/venia-concept/src/components/PurchaseDetailsPage/OrderItem/ButtonGroup/__tests__/buttonGroup.spec.js
@@ -1,0 +1,52 @@
+import React from 'react';
+import { configure, shallow } from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
+import ButtonGroup from '../buttonGroup';
+import Button from 'src/components/Button';
+
+configure({ adapter: new Adapter() });
+
+const classes = {
+    buttonGroupItem: 'buttonGroupItem',
+    textNodeContainer: 'textNodeContainer'
+};
+
+const buttonGroupItemsMock = [
+    {
+        onClickHandler: jest.fn(),
+        iconName: 'icon1',
+        textNode: 'text1'
+    },
+    {
+        onClickHandler: jest.fn(),
+        iconName: 'icon2',
+        textNode: 'text2'
+    }
+];
+
+afterEach(() => {
+    buttonGroupItemsMock.forEach(button => button.onClickHandler.mockReset());
+});
+
+test('renders all button group items correctly', () => {
+    const wrapper = shallow(
+        <ButtonGroup buttonGroupItems={buttonGroupItemsMock} />
+    ).dive();
+
+    expect(wrapper.find(Button)).toHaveLength(buttonGroupItemsMock.length);
+});
+
+test('clicking buttons triggers appropriate handlers', () => {
+    const wrapper = shallow(
+        <ButtonGroup
+            classes={classes}
+            buttonGroupItems={buttonGroupItemsMock}
+        />
+    ).dive();
+
+    wrapper.find(Button).forEach((buttonNode, index) => {
+        const { onClickHandler } = buttonGroupItemsMock[index];
+        buttonNode.simulate('click');
+        expect(onClickHandler).toHaveBeenCalledTimes(1);
+    });
+});

--- a/packages/venia-concept/src/components/PurchaseDetailsPage/OrderItem/__tests__/orderItem.spec.js
+++ b/packages/venia-concept/src/components/PurchaseDetailsPage/OrderItem/__tests__/orderItem.spec.js
@@ -1,0 +1,47 @@
+import React from 'react';
+import { configure, shallow } from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
+import OrderItem from '../orderItem';
+import ButtonGroup from '../ButtonGroup';
+
+configure({ adapter: new Adapter() });
+
+const itemMock = {
+    id: 1,
+    name: 'name',
+    size: '43',
+    color: 'color',
+    qty: 1,
+    titleImageSrc: 'picturePath',
+    price: 10,
+    sku: '24-MB01'
+};
+
+const classes = {
+    main: 'main',
+    imageAndPropsContainer: 'imageAndPropsContainer',
+    titleImage: 'titleImage',
+    propsColumnContainer: 'propsColumnContainer',
+    priceContainer: 'priceContainer'
+};
+
+test('renders correctly', () => {
+    const onBuyAgainMock = jest.fn();
+    const onShareMock = jest.fn();
+
+    const wrapper = shallow(
+        <OrderItem
+            classes={classes}
+            item={itemMock}
+            onBuyAgain={onBuyAgainMock}
+            onShare={onShareMock}
+        />
+    ).dive();
+
+    expect(wrapper.find(`.${classes.main}`)).toHaveLength(1);
+    expect(wrapper.find(`.${classes.imageAndPropsContainer}`)).toHaveLength(1);
+    expect(wrapper.find(`.${classes.titleImage}`)).toHaveLength(1);
+    expect(wrapper.find(`.${classes.propsColumnContainer}`)).toHaveLength(1);
+    expect(wrapper.find(`.${classes.priceContainer}`)).toHaveLength(1);
+    expect(wrapper.find(ButtonGroup)).toHaveLength(1);
+});

--- a/packages/venia-concept/src/components/PurchaseDetailsPage/OrderItemsList/__tests__/orderItemsList.spec.js
+++ b/packages/venia-concept/src/components/PurchaseDetailsPage/OrderItemsList/__tests__/orderItemsList.spec.js
@@ -1,0 +1,43 @@
+import React from 'react';
+import { configure, shallow } from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
+import { List } from '@magento/peregrine';
+import OrderItemsList from '../OrderItemsList';
+
+configure({ adapter: new Adapter() });
+
+const classes = {
+    header: 'header'
+};
+
+const itemsMock = [
+    {
+        id: 1,
+        name: 'name',
+        size: '42',
+        color: 'color',
+        qty: 1,
+        titleImageSrc: 'picture',
+        price: 27,
+        sku: 'sku'
+    },
+    {
+        id: 2,
+        name: 'name',
+        size: '42',
+        color: 'color',
+        qty: 1,
+        titleImageSrc: 'picture',
+        price: 27,
+        sku: 'sku'
+    }
+];
+
+test('renders correctly', () => {
+    const wrapper = shallow(
+        <OrderItemsList classes={classes} title="title" items={itemsMock} />
+    ).dive();
+
+    expect(wrapper.find(`.${classes.header}`)).toHaveLength(1);
+    expect(wrapper.find(List)).toHaveLength(1);
+});

--- a/packages/venia-concept/src/reducers/__tests__/purchaseDetails.spec.js
+++ b/packages/venia-concept/src/reducers/__tests__/purchaseDetails.spec.js
@@ -1,0 +1,8 @@
+import purchaseDetailsReducer from '../purchaseDetails';
+import actions from 'src/actions/purchaseDetails';
+
+test('purchaseDetails.request: toggle isFetching to true', () => {
+    expect(
+        purchaseDetailsReducer({ isFetching: false }, { type: actions.request })
+    ).toEqual({ isFetching: true });
+});


### PR DESCRIPTION
<!-- (REQUIRED) What is the nature of this PR? -->

## This PR is a:

[ X ] New feature
[ ] Enhancement/Optimization
[ ] Refactor
[ ] Bugfix
[ ] Test for existing code
[ ] Documentation

Tests for order item, order item list, button group, and also for actions, reducer.

## Summary

When this pull request is merged, it will...

<!-- (OPTIONAL) What other information can you provide about this PR? -->

## Additional information

<!--
Thank you for your contribution!

Before submitting this pull request, please make sure you have read our Contribution Guidelines and your PR meets our contribution standards:
https://github.com/magento-research/pwa-studio/blob/master/.github/CONTRIBUTION.md

Please fill out as much information as you can about your PR to help speed up the review process.
If your PR addresses an existing GitHub Issue, please refer to it in the title or Additional Information section to make the connection.

We may ask you for changes in your PR in order to meet the standards set in our Contribution Guidelines. PR's that do not comply with our guidelines may be closed at the maintainers' discretion.

Feel free to remove this section before creating this PR.
-->
