### PR TITLE
Add async actions tests for purchase history

### DIFF
--- a/packages/venia-concept/src/actions/purchaseHistory/__tests__/asyncActions.spec.js
+++ b/packages/venia-concept/src/actions/purchaseHistory/__tests__/asyncActions.spec.js
@@ -1,5 +1,50 @@
+import { dispatch, getState } from 'src/store';
 import { getPurchaseHistory } from '../asyncActions';
+import actions from '../actions';
+import * as api from '../api';
+
+jest.mock('src/store');
+
+jest.mock('../api', () => ({
+    fetchPurchaseHistory: jest.fn()
+}));
+
+const thunkArgs = [dispatch, getState];
+
+afterEach(() => {
+    dispatch.mockClear();
+});
 
 test('getPurchaseHistory() to return a thunk', () => {
     expect(getPurchaseHistory()).toBeInstanceOf(Function);
+});
+
+test('getPurchaseHistory thunk dispatches actions on success', async () => {
+    const response = {
+        items: []
+    };
+
+    api.fetchPurchaseHistory.mockResolvedValueOnce(response);
+
+    await getPurchaseHistory()(...thunkArgs);
+
+    expect(dispatch).toHaveBeenNthCalledWith(
+        1,
+        actions.fetchPurchaseHistoryRequest()
+    );
+    expect(dispatch).toHaveBeenNthCalledWith(2, actions.setItems(response));
+});
+
+test('getPurchaseHistory thunk dispatches actions on error', async () => {
+    const error = new Error();
+
+    api.fetchPurchaseHistory.mockResolvedValueOnce(error);
+
+    await getPurchaseHistory()(...thunkArgs);
+
+    expect(dispatch).toHaveBeenNthCalledWith(
+        1,
+        actions.fetchPurchaseHistoryRequest()
+    );
+    expect(dispatch).toHaveBeenNthCalledWith(2, actions.setItems(error));
 });


### PR DESCRIPTION
<!-- (REQUIRED) What is the nature of this PR? -->

## This PR is a:

[ ] New feature
[ ] Enhancement/Optimization
[ ] Refactor
[ ] Bugfix
[x] Test for existing code
[ ] Documentation

<!-- (REQUIRED) What does this PR change? -->

## Summary

Add async actions tests for purchase history

<!-- (OPTIONAL) What other information can you provide about this PR? -->

## Additional information

<!--
Thank you for your contribution!

Before submitting this pull request, please make sure you have read our Contribution Guidelines and your PR meets our contribution standards:
https://github.com/magento-research/pwa-studio/blob/master/.github/CONTRIBUTION.md

Please fill out as much information as you can about your PR to help speed up the review process.
If your PR addresses an existing GitHub Issue, please refer to it in the title or Additional Information section to make the connection.

We may ask you for changes in your PR in order to meet the standards set in our Contribution Guidelines. PR's that do not comply with our guidelines may be closed at the maintainers' discretion.

Feel free to remove this section before creating this PR.
-->
