### PR TITLE
Add render states functions to List

### DIFF
--- a/packages/peregrine/src/List/__tests__/list.spec.js
+++ b/packages/peregrine/src/List/__tests__/list.spec.js
@@ -128,3 +128,21 @@ test('does not throw if `onSelectionChange` is not provided', () => {
     const cb = () => wrapper.instance().handleSelectionChange(selection);
     expect(cb).not.toThrow();
 });
+
+test('renders loading state when list items are loading', () => {
+    const renderLoadingState = jest.fn();
+    const props = { items, isLoading: true, renderLoadingState };
+
+    shallow(<List {...props} />);
+
+    expect(renderLoadingState).toBeCalled();
+});
+
+test('renders empty state when items array is empty', () => {
+    const renderEmptyState = jest.fn();
+    const props = { items: [], renderEmptyState };
+
+    shallow(<List {...props} />);
+
+    expect(renderEmptyState).toBeCalled();
+});

--- a/packages/peregrine/src/List/list.js
+++ b/packages/peregrine/src/List/list.js
@@ -16,7 +16,10 @@ class List extends Component {
             .isRequired,
         renderItem: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
         onSelectionChange: PropTypes.func,
-        selectionModel: PropTypes.oneOf(['checkbox', 'radio'])
+        selectionModel: PropTypes.oneOf(['checkbox', 'radio']),
+        isLoading: PropTypes.bool,
+        renderLoadingState: PropTypes.func,
+        renderEmptyState: PropTypes.func
     };
 
     static defaultProps = {
@@ -25,7 +28,8 @@ class List extends Component {
         items: [],
         render: 'div',
         renderItem: 'div',
-        selectionModel: 'radio'
+        selectionModel: 'radio',
+        isLoading: false
     };
 
     render() {
@@ -37,8 +41,19 @@ class List extends Component {
             renderItem,
             onSelectionChange,
             selectionModel,
+            isLoading,
+            renderLoadingState,
+            renderEmptyState,
             ...restProps
         } = this.props;
+
+        if (isLoading && renderLoadingState) {
+            return renderLoadingState();
+        }
+
+        if (items && items.length === 0 && renderEmptyState) {
+            return renderEmptyState();
+        }
 
         const customProps = {
             classes,


### PR DESCRIPTION
<!-- (REQUIRED) What is the nature of this PR? -->

## This PR is a:

[x] New feature
[ ] Enhancement/Optimization
[ ] Refactor
[ ] Bugfix
[ ] Test for existing code
[ ] Documentation

<!-- (REQUIRED) What does this PR change? -->

## Summary

When this pull request is merged, it will allow us to pass functions to List component to render separate list states.

https://github.com/magento-research/pwa-studio/issues/503

**Example of usage:**

```
<List
    isLoading={isFetching}
    items={items}
    getItemKey={({ id }) => id}
    render={props => (
        <ul className={classes.itemsContainer}>{props.children}</ul>
    )}
    renderItem={props => (
        <li className={classes.item}>
            <PurchaseHistoryItem {...props} />
        </li>
    )}
    renderLoadingState={() => (
        <div>Loading</div>
    )}
    renderEmptyState={() => (
        <div>Purchase history is empty.</div>
    )}
/>
```

<!-- (OPTIONAL) What other information can you provide about this PR? -->

## Additional information

<!--
Thank you for your contribution!

Before submitting this pull request, please make sure you have read our Contribution Guidelines and your PR meets our contribution standards:
https://github.com/magento-research/pwa-studio/blob/master/.github/CONTRIBUTION.md

Please fill out as much information as you can about your PR to help speed up the review process.
If your PR addresses an existing GitHub Issue, please refer to it in the title or Additional Information section to make the connection.

We may ask you for changes in your PR in order to meet the standards set in our Contribution Guidelines. PR's that do not comply with our guidelines may be closed at the maintainers' discretion.

Feel free to remove this section before creating this PR.
-->
