### PR TITLE
Remodel address form from checkout, add validation for the state field

### DIFF
--- a/packages/venia-concept/src/actions/checkout/__tests__/actions.spec.js
+++ b/packages/venia-concept/src/actions/checkout/__tests__/actions.spec.js
@@ -90,6 +90,20 @@ test('input.reject() returns a proper action object', () => {
     });
 });
 
+test('input.incorrectAddress.toString() returns the proper action type', () => {
+    expect(actions.input.incorrectAddress.toString()).toBe(
+        'CHECKOUT/INPUT/INCORRECT_ADDRESS'
+    );
+});
+
+test('input.incorrectAddress() returns a proper action object', () => {
+    const payload = { incorrectAddressMessage: error.message };
+    expect(actions.input.incorrectAddress(payload)).toEqual({
+        type: 'CHECKOUT/INPUT/INCORRECT_ADDRESS',
+        payload
+    });
+});
+
 test('order.submit.toString() returns the proper action type', () => {
     expect(actions.order.submit.toString()).toBe('CHECKOUT/ORDER/SUBMIT');
 });

--- a/packages/venia-concept/src/actions/checkout/__tests__/asyncActions.spec.js
+++ b/packages/venia-concept/src/actions/checkout/__tests__/asyncActions.spec.js
@@ -157,7 +157,7 @@ test('submitInput thunk throws if there is no guest cart', async () => {
 
 test('submitInput thunk dispatches action on incorrect state(region code)', async () => {
     const invalidState = 'any_text';
-    const incorrectAddressMessage = `Region "${invalidState}" is not an available region.`;
+    const incorrectAddressMessage = `State "${invalidState}" is not an valid state abbreviation.`;
     const incorrectAddressPayload = { incorrectAddressMessage };
     const submitPayload = {
         type: 'address',
@@ -265,5 +265,5 @@ test('formatAddress throws if region is not found', () => {
     const values = { region_code: '|||' };
     const shouldThrow = () => formatAddress(values, countries);
 
-    expect(shouldThrow).toThrow('region');
+    expect(shouldThrow).toThrow('state');
 });

--- a/packages/venia-concept/src/actions/checkout/__tests__/asyncActions.spec.js
+++ b/packages/venia-concept/src/actions/checkout/__tests__/asyncActions.spec.js
@@ -155,13 +155,26 @@ test('submitInput thunk throws if there is no guest cart', async () => {
     );
 });
 
-test('submitInput thunk throws if payload is invalid', async () => {
-    const payload = { type: 'address', formValues: {} };
+test('submitInput thunk dispatches action on incorrect state(region code)', async () => {
+    const invalidState = 'any_text';
+    const incorrectAddressMessage = `Region "${invalidState}" is not an available region.`;
+    const incorrectAddressPayload = { incorrectAddressMessage };
+    const submitPayload = {
+        type: 'address',
+        formValues: { region_code: invalidState }
+    };
 
-    await expect(submitInput(payload)(...thunkArgs)).rejects.toThrow();
-    expect(dispatch).toHaveBeenNthCalledWith(1, actions.input.submit(payload));
+    await submitInput(submitPayload)(...thunkArgs);
+    expect(dispatch).toHaveBeenNthCalledWith(
+        1,
+        actions.input.submit(submitPayload)
+    );
     expect(dispatch).toHaveBeenNthCalledWith(2, expect.any(Function));
-    expect(dispatch).toHaveBeenCalledTimes(2);
+    expect(dispatch).toHaveBeenNthCalledWith(
+        3,
+        actions.input.incorrectAddress(incorrectAddressPayload)
+    );
+    expect(dispatch).toHaveBeenCalledTimes(3);
 });
 
 test('submitOrder() returns a thunk', () => {

--- a/packages/venia-concept/src/actions/checkout/actions.js
+++ b/packages/venia-concept/src/actions/checkout/actions.js
@@ -10,7 +10,8 @@ const actionMap = {
     INPUT: {
         SUBMIT: null,
         ACCEPT: null,
-        REJECT: null
+        REJECT: null,
+        INCORRECT_ADDRESS: null
     },
     ORDER: {
         SUBMIT: null,

--- a/packages/venia-concept/src/actions/checkout/asyncActions.js
+++ b/packages/venia-concept/src/actions/checkout/asyncActions.js
@@ -43,7 +43,12 @@ export const submitInput = payload =>
         try {
             address = formatAddress(address, countries);
         } catch (error) {
-            throw error;
+            dispatch(
+                actions.input.incorrectAddress({
+                    incorrectAddressMessage: error.message
+                })
+            );
+            return null;
         }
 
         try {
@@ -131,7 +136,6 @@ export function formatAddress(address = {}, countries = []) {
     if (!country) {
         throw new Error('Country "US" is not an available country.');
     }
-
     const { region_code } = address;
     const { available_regions: regions } = country;
 
@@ -142,7 +146,7 @@ export function formatAddress(address = {}, countries = []) {
     const region = regions.find(({ code }) => code === region_code);
 
     if (!region) {
-        throw new Error(`Region "${region_code}" is not an available region.`);
+        throw new Error(`State "${region_code}" is not an valid state abbreviation.`);
     }
 
     return {

--- a/packages/venia-concept/src/actions/checkout/asyncActions.js
+++ b/packages/venia-concept/src/actions/checkout/asyncActions.js
@@ -146,7 +146,9 @@ export function formatAddress(address = {}, countries = []) {
     const region = regions.find(({ code }) => code === region_code);
 
     if (!region) {
-        throw new Error(`State "${region_code}" is not an valid state abbreviation.`);
+        throw new Error(
+            `State "${region_code}" is not an valid state abbreviation.`
+        );
     }
 
     return {

--- a/packages/venia-concept/src/components/Checkout/address.css
+++ b/packages/venia-concept/src/components/Checkout/address.css
@@ -1,4 +1,5 @@
 .root {
+    grid-template-columns: 50% 50%;
 }
 
 .body {
@@ -24,21 +25,30 @@
 /* fields */
 
 .textInput {
-    background: white;
+    --default-reset-button-width: 24px;
+    composes: input from 'src/components/Input/input.css';
     border: 1px solid rgb(var(--venia-text-alt));
     border-radius: 2px;
-    color: rgb(var(--venia-text));
-    display: inline-flex;
-    flex: 0 0 100%;
-    font-size: 0.9375rem;
     height: 2.25rem;
-    padding: calc(0.375rem - 1px) calc(0.625rem - 1px);
-    width: 100%;
+    font-size: 0.9375rem;
+    padding: calc(0.375rem - 1px) var(--input-right-padding);
+    padding-right: calc(
+        var(--input-right-padding) + var(--default-reset-button-width)
+    );
+    color: rgb(var(--venia-text));
 }
 
 .textInput:focus {
     border-color: rgb(var(--venia-text));
-    outline: 0 none;
+}
+
+.inputRoot {
+    padding: 0;
+    --input-right-padding: calc(0.625rem - 1px);
+}
+
+.inputRootFocused {
+    composes: inputRoot;
 }
 
 .city,
@@ -51,11 +61,13 @@
 }
 
 .email,
-.street0 {
+.street {
     grid-column-end: span 2;
 }
 
-.validation {
+.serverValidation {
     grid-column-end: span 2;
     line-height: normal;
+    text-align: center;
+    color: red;
 }

--- a/packages/venia-concept/src/components/Checkout/address.css
+++ b/packages/venia-concept/src/components/Checkout/address.css
@@ -54,3 +54,8 @@
 .street0 {
     grid-column-end: span 2;
 }
+
+.validation {
+    grid-column-end: span 2;
+    line-height: normal;
+}

--- a/packages/venia-concept/src/components/Checkout/address.js
+++ b/packages/venia-concept/src/components/Checkout/address.js
@@ -1,11 +1,13 @@
 import React, { Component, Fragment } from 'react';
 import { Form, Text } from 'informed';
 import memoize from 'memoize-one';
-import { func, shape, string } from 'prop-types';
+import { func, shape, string, bool } from 'prop-types';
 
 import classify from 'src/classify';
 import Button from 'src/components/Button';
 import Label from './label';
+import { invalidStateMessage } from './constants';
+import { isString } from 'util';
 import defaultClasses from './address.css';
 
 const fields = [
@@ -39,9 +41,28 @@ class AddressForm extends Component {
             postcode: string,
             region_code: string,
             street0: string,
-            telephone: string
+            telephone: string,
+            validation: string
         }),
-        submit: func
+        submit: func,
+        isAddressIncorrect: bool,
+        incorrectAddressMessage: string
+    };
+
+    //TODO: implement appropriate validation for the state field
+    validateState = value => {
+        return isString(value) && value.length > 1 ? null : invalidStateMessage;
+    };
+
+    validationBlock = errors => {
+        const { isAddressIncorrect, incorrectAddressMessage } = this.props;
+        if (errors.region_code) {
+            return errors.region_code;
+        } else if (isAddressIncorrect) {
+            return incorrectAddressMessage;
+        } else {
+            return null;
+        }
     };
 
     render() {
@@ -60,7 +81,7 @@ class AddressForm extends Component {
         );
     }
 
-    children = () => {
+    children = ({ formState }) => {
         const { classes, submitting } = this.props;
 
         return (
@@ -113,6 +134,7 @@ class AddressForm extends Component {
                             id={classes.region_code}
                             field="region_code"
                             className={classes.textInput}
+                            validate={this.validateState}
                         />
                     </div>
                     <div className={classes.telephone}>
@@ -130,6 +152,9 @@ class AddressForm extends Component {
                             field="email"
                             className={classes.textInput}
                         />
+                    </div>
+                    <div className={classes.validation}>
+                        {this.validationBlock(formState.errors)}
                     </div>
                 </div>
                 <div className={classes.footer}>

--- a/packages/venia-concept/src/components/Checkout/constants.js
+++ b/packages/venia-concept/src/components/Checkout/constants.js
@@ -1,3 +1,21 @@
-//TODO: write appropriate validation error message
-export const invalidStateMessage =
-    'State field must contain at least 2 characters';
+export const fields = {
+    firstname: 'firstname',
+    lastname: 'lastname',
+    street: 'street[0]',
+    city: 'city',
+    postcode: 'postcode',
+    region_code: 'region_code',
+    telephone: 'telephone',
+    email: 'email'
+};
+
+export const fieldsLabels = {
+    city: 'City',
+    email: 'Email',
+    firstname: 'First Name',
+    lastname: 'Last Name',
+    postcode: 'ZIP',
+    region_code: 'State',
+    street: 'Street',
+    telephone: 'Phone'
+};

--- a/packages/venia-concept/src/components/Checkout/constants.js
+++ b/packages/venia-concept/src/components/Checkout/constants.js
@@ -1,0 +1,3 @@
+//TODO: write appropriate validation error message
+export const invalidStateMessage =
+    'State field must contain at least 2 characters';

--- a/packages/venia-concept/src/components/Checkout/flow.js
+++ b/packages/venia-concept/src/components/Checkout/flow.js
@@ -33,7 +33,9 @@ class Flow extends Component {
         checkout: shape({
             editing: string,
             step: string,
-            submitting: bool
+            submitting: bool,
+            isAddressIncorrect: bool,
+            incorrectAddressMessage: string
         }),
         classes: shape({
             root: string
@@ -43,7 +45,13 @@ class Flow extends Component {
     get child() {
         const { actions, cart, checkout } = this.props;
         const { beginCheckout, editOrder, submitInput, submitOrder } = actions;
-        const { editing, step, submitting } = checkout;
+        const {
+            editing,
+            step,
+            submitting,
+            isAddressIncorrect,
+            incorrectAddressMessage
+        } = checkout;
         const { details } = cart;
         const ready = isCartReady(details.items_count);
         const valid = isAddressValid(details.billing_address);
@@ -65,7 +73,13 @@ class Flow extends Component {
                     valid
                 };
 
-                return <Form {...stepProps} />;
+                const formProps = {
+                    ...stepProps,
+                    isAddressIncorrect,
+                    incorrectAddressMessage
+                };
+
+                return <Form {...formProps} />;
             }
             case 3: {
                 return <Receipt />;

--- a/packages/venia-concept/src/components/Checkout/flow.js
+++ b/packages/venia-concept/src/components/Checkout/flow.js
@@ -3,7 +3,7 @@ import { bool, func, object, shape, string } from 'prop-types';
 
 import classify from 'src/classify';
 import Cart from './cart';
-import Form from './form';
+import Form from './formContainer';
 import Receipt from './Receipt';
 import defaultClasses from './flow.css';
 
@@ -45,13 +45,7 @@ class Flow extends Component {
     get child() {
         const { actions, cart, checkout } = this.props;
         const { beginCheckout, editOrder, submitInput, submitOrder } = actions;
-        const {
-            editing,
-            step,
-            submitting,
-            isAddressIncorrect,
-            incorrectAddressMessage
-        } = checkout;
+        const { editing, step, submitting } = checkout;
         const { details } = cart;
         const ready = isCartReady(details.items_count);
         const valid = isAddressValid(details.billing_address);
@@ -73,13 +67,7 @@ class Flow extends Component {
                     valid
                 };
 
-                const formProps = {
-                    ...stepProps,
-                    isAddressIncorrect,
-                    incorrectAddressMessage
-                };
-
-                return <Form {...formProps} />;
+                return <Form {...stepProps} />;
             }
             case 3: {
                 return <Receipt />;

--- a/packages/venia-concept/src/components/Checkout/form.js
+++ b/packages/venia-concept/src/components/Checkout/form.js
@@ -1,10 +1,8 @@
 import React, { Component, Fragment } from 'react';
 import { bool, func, object, shape, string } from 'prop-types';
 
-import classify from 'src/classify';
 import Section from './section';
 import SubmitButton from './submitButton';
-import defaultClasses from './form.css';
 
 import AddressForm from './address';
 
@@ -132,4 +130,4 @@ class Form extends Component {
     };
 }
 
-export default classify(defaultClasses)(Form);
+export default Form;

--- a/packages/venia-concept/src/components/Checkout/form.js
+++ b/packages/venia-concept/src/components/Checkout/form.js
@@ -29,7 +29,13 @@ class Form extends Component {
     };
 
     get editableForm() {
-        const { cart, editing, submitting } = this.props;
+        const {
+            cart,
+            editing,
+            submitting,
+            isAddressIncorrect,
+            incorrectAddressMessage
+        } = this.props;
 
         switch (editing) {
             case 'address': {
@@ -41,6 +47,8 @@ class Form extends Component {
                         submitting={submitting}
                         cancel={this.stopEditing}
                         submit={this.submitAddress}
+                        isAddressIncorrect={isAddressIncorrect}
+                        incorrectAddressMessage={incorrectAddressMessage}
                     />
                 );
             }

--- a/packages/venia-concept/src/components/Checkout/formContainer.js
+++ b/packages/venia-concept/src/components/Checkout/formContainer.js
@@ -1,0 +1,14 @@
+import { connect } from 'react-redux';
+import { compose } from 'redux';
+import classify from 'src/classify';
+import Form from './form';
+import defaultClasses from './form.css';
+
+const mapStateToProps = ({
+    checkout: { isAddressIncorrect, incorrectAddressMessage }
+}) => ({ isAddressIncorrect, incorrectAddressMessage });
+
+export default compose(
+    classify(defaultClasses),
+    connect(mapStateToProps)
+)(Form);

--- a/packages/venia-concept/src/components/Checkout/helpers.js
+++ b/packages/venia-concept/src/components/Checkout/helpers.js
@@ -1,0 +1,11 @@
+import { isString } from 'util';
+
+//TODO: write proper validation error message
+const invalidStateFieldMessage = 'State field must be at least 2 characters';
+
+//TODO: implement proper validation for the state field
+export const validatorStateField = value => {
+    return isString(value) && value.length > 1
+        ? null
+        : invalidStateFieldMessage;
+};

--- a/packages/venia-concept/src/components/CreateAccount/__tests__/createAccount.spec.js
+++ b/packages/venia-concept/src/components/CreateAccount/__tests__/createAccount.spec.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { configure, shallow, mount } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 import CreateAccount from '../createAccount';
+import { fields } from '../constants';
 
 configure({ adapter: new Adapter() });
 
@@ -18,15 +19,16 @@ let blankState = {
 };
 
 let state = {
-    firstName: 'Test',
-    lastName: 'Test Test',
-    email: 'test@test.com',
-    password: 'test',
-    passwordConfirm: 'test',
-    subscribe: false,
     checkingEmail: false,
     emailAvailable: true,
-    subscribe: true
+    subscribe: false,
+    formFields: {
+        [fields.firstName]: 'Test',
+        [fields.familyName]: 'Test Test',
+        [fields.email]: 'test@test.com',
+        [fields.password]: 'test',
+        [fields.confirmPassword]: 'test'
+    }
 };
 
 jest.mock('@magento/peregrine', () => {
@@ -53,19 +55,6 @@ const classes = {
     createAccountButton: 'a',
     root: 'b'
 };
-
-// jest.useFakeTimers();
-
-test('correctly checks if password and passwordConfirm match', () => {
-    const wrapper = shallow(<CreateAccount />).dive();
-    wrapper.setState(state);
-    expect(wrapper.instance().hasPasswordConfirmError).toBe(false);
-    let incorrectPassState = Object.assign({}, state);
-    incorrectPassState.passwordConfirm =
-        incorrectPassState.passwordConfirm + 'wrong!';
-    wrapper.setState(incorrectPassState);
-    expect(wrapper.instance().hasPasswordConfirmError).toBe(true);
-});
 
 test('Enables the create account button when all forms are filled in and passwords match', () => {
     const wrapper = shallow(<CreateAccount />).dive();

--- a/packages/venia-concept/src/components/CreateAccount/constants.js
+++ b/packages/venia-concept/src/components/CreateAccount/constants.js
@@ -1,0 +1,7 @@
+export const fields = {
+    email: 'email',
+    firstName: 'first-name',
+    familyName: 'family-name',
+    password: 'password',
+    confirmPassword: 'confirm-password'
+};

--- a/packages/venia-concept/src/components/Input/__tests__/input.spec.js
+++ b/packages/venia-concept/src/components/Input/__tests__/input.spec.js
@@ -1,90 +1,76 @@
 import React from 'react';
 import { configure, shallow } from 'enzyme';
+import { BasicText } from 'informed';
 import Adapter from 'enzyme-adapter-react-16';
-import Input from '../input';
+import { Input } from '../input';
 
 configure({ adapter: new Adapter() });
 
-const validInput = {
-    value: 'example value',
+const helpType = 'hint';
+const classes = {
+    resetInput: 'resetInput',
+    hint: helpType
+};
+
+const validInputProps = {
+    initialValue: 'example initial value',
+    fieldState: {
+        value: 'example value'
+    },
     placeholder: 'Enter username here',
     label: 'Username',
     type: 'Text',
     disabled: false,
     required: false,
     helpText: 'example help text',
-    helpVisible: true,
-    errorVisible: true,
-    successVisible: true,
-    onChange: null,
-    field: 'value'
+    helpType,
+    onChange: () => null,
+    onFocus: () => null,
+    onBlur: () => null,
+    field: 'value',
+    selected: false,
+    validate: () => null,
+    validateOnChange: true,
+    classes
 };
 
 test('correctly assigns all props passed to `input` field', () => {
-    const wrapper = shallow(
-        <Input
-            label={validInput.label}
-            type={validInput.type}
-            disabled={validInput.disabled}
-            placeholder={validInput.placeholder}
-            required={validInput.required}
-            field={validInput.field}
-        />
-    );
-
-    const wrapperProps = wrapper
-        .dive()
-        .find('Text')
-        .props();
+    const wrapper = shallow(<Input {...validInputProps} />);
+    const wrapperProps = wrapper.find(BasicText).props();
 
     const typeProp = wrapperProps.type;
-    expect(typeProp).toEqual(validInput.type);
+    expect(typeProp).toEqual(validInputProps.type);
 
     const disabledProp = wrapperProps.disabled;
-    expect(disabledProp).toEqual(validInput.disabled);
+    expect(disabledProp).toEqual(validInputProps.disabled);
 
     const placeholderProp = wrapperProps.placeholder;
-    expect(placeholderProp).toEqual(validInput.placeholder);
+    expect(placeholderProp).toEqual(validInputProps.placeholder);
 
-    const requiredProp = wrapperProps.required;
-    expect(requiredProp).toEqual(validInput.required);
+    const initialValueProp = wrapperProps.initialValue;
+    expect(initialValueProp).toEqual(validInputProps.initialValue);
 });
 
-test('displays `helpText` when `helpVisible`', () => {
-    const wrapper = shallow(
-        <Input
-            label={validInput.label}
-            helpText={validInput.helpText}
-            helpVisible={validInput.helpVisible}
-            field={validInput.field}
-        />
-    ).dive();
+test('displays `helpText` when it has been passed', () => {
+    const wrapper = shallow(<Input {...validInputProps} />);
 
-    const helpText = shallow(wrapper.instance().helpText);
-    expect(helpText.html()).toContain(validInput.helpText);
-});
-
-test('set `value` state when text is entered into `input`', () => {
-    const changeValue = 'foo';
-    const event = {
-        preventDefault() {},
-        target: { value: changeValue }
-    };
-
-    const wrapper = shallow(
-        <Input label={validInput.label} field={validInput.field} />
-    ).dive();
-
-    wrapper.find('Text').prop('onChange')(event);
-    expect(wrapper.state().value).toBe(changeValue);
+    expect(wrapper.find(`.${classes[helpType]}`)).toHaveLength(1);
 });
 
 test('set state to `focused` on `Text` focus', () => {
-    const wrapper = shallow(
-        <Input label={validInput.label} field={validInput.field} />
-    ).dive();
+    const wrapper = shallow(<Input {...validInputProps} />);
 
     expect(wrapper.state().focused).toBeFalsy();
-    wrapper.find('Text').simulate('focus');
+    wrapper.find(BasicText).simulate('focus');
     expect(wrapper.state().focused).toBeTruthy();
+});
+
+test('display reset button only when text has been typed in input', () => {
+    const wrapperFilled = shallow(<Input {...validInputProps} />);
+    expect(wrapperFilled.find(`.${classes.resetInput}`)).toHaveLength(1);
+
+    const wrapperEmpty = shallow(
+        <Input {...validInputProps} fieldState={{ value: '' }} />
+    );
+    expect(wrapperEmpty.find(`.${classes.resetInput}`)).toHaveLength(0);
 });

--- a/packages/venia-concept/src/components/Input/constants.js
+++ b/packages/venia-concept/src/components/Input/constants.js
@@ -1,0 +1,12 @@
+export const HelpTypes = {
+    hint: 'hint',
+    error: 'error',
+    success: 'success'
+};
+//when changing icon size also it is need to change right padding in input
+export const resetButtonIcon = {
+    name: 'x',
+    attrs: {
+        color: 'red'
+    }
+};

--- a/packages/venia-concept/src/components/Input/helpers.js
+++ b/packages/venia-concept/src/components/Input/helpers.js
@@ -1,0 +1,22 @@
+import { isString } from 'util';
+
+const emptyFieldMessage = 'This field cannot be empty';
+export const defaultIsRequired = value =>
+    isString(value) && value.length > 0 ? null : emptyFieldMessage;
+
+export const createComplexValidator = validators => (value, values = null) => {
+    for (let i = 0; i < validators.length; i++) {
+        const validatorOutput = validators[i](value, values);
+
+        if (validatorOutput) {
+            return validatorOutput;
+        } else if (i + 1 < validators.length) {
+            // If current iteration is on the last validator
+            // and this validator hasn't returned error
+            // we need to return null as result of whole complex valdiator
+            continue;
+        } else {
+            return null;
+        }
+    }
+};

--- a/packages/venia-concept/src/components/Input/index.js
+++ b/packages/venia-concept/src/components/Input/index.js
@@ -1,2 +1,3 @@
 export { default } from './input';
-export { HelpTypes } from './input';
+export { HelpTypes } from './constants';
+export { createComplexValidator, defaultIsRequired } from './helpers';

--- a/packages/venia-concept/src/components/Input/input.css
+++ b/packages/venia-concept/src/components/Input/input.css
@@ -1,16 +1,8 @@
-.helpText {
+.hint,
+.error,
+.success {
     font-size: 0.7rem;
     margin: 0.4rem 0;
-}
-
-.requiredSymbol {
-    background-color: rgb(var(--venia-text-spot));
-    width: 0.4em;
-    height: 0.4em;
-    margin-top: 0.1em;
-    border-radius: 50%;
-    display: inline-block;
-    vertical-align: top;
 }
 
 .hint {
@@ -25,16 +17,52 @@
     color: green;
 }
 
+.requiredSymbol {
+    background-color: rgb(var(--venia-text-spot));
+    width: 0.4em;
+    height: 0.4em;
+    margin-top: 0.1em;
+    border-radius: 50%;
+    display: inline-block;
+    vertical-align: top;
+}
+
 .root {
     padding: 0.5rem 1.5rem;
+    --input-right-padding: 1rem;
+}
+
+.rootFocused {
+    composes: root;
+    background-color: rgb(var(--venia-teal-alt));
+    transition: 200ms;
+}
+
+.inputContainer {
+    position: relative;
 }
 
 .input {
+    --default-reset-button-width: 24px;
     width: 100%;
     height: 1.85rem;
     border: 1px solid black;
-    padding: 1rem;
+    padding: var(--input-right-padding);
+    padding-right: calc(
+        var(--input-right-padding) + var(--default-reset-button-width)
+    );
     margin: 0.2rem 0 0 0;
+    outline: none;
+}
+
+.resetInput {
+    display: flex;
+    justify-content: center;
+    position: absolute;
+    top: 50%;
+    right: var(--input-right-padding);
+    transform: translateY(-50%);
+    background-color: transparent;
     outline: none;
 }
 
@@ -43,11 +71,7 @@
 }
 
 .labelFocused {
+    composes: label;
     color: rgb(var(--venia-teal));
-    transition: 200ms;
-}
-
-.rootFocused {
-    background-color: rgb(var(--venia-teal-alt));
     transition: 200ms;
 }

--- a/packages/venia-concept/src/components/SignIn/__tests__/signIn.spec.js
+++ b/packages/venia-concept/src/components/SignIn/__tests__/signIn.spec.js
@@ -14,30 +14,6 @@ const classes = {
     signInButton: 'a'
 };
 
-test('set state `password` to new `password` on `updatePassword`', () => {
-    const wrapper = shallow(
-        <SignIn signIn={props.signIn} signInError={props.signInError} />
-    ).dive();
-
-    const newPassword = 'foo';
-
-    expect(wrapper.state().password).toEqual('');
-    wrapper.instance().updatePassword(newPassword);
-    expect(wrapper.state().password).toEqual(newPassword);
-});
-
-test('set state `username` to new `username` on `updateUsername`', () => {
-    const wrapper = shallow(
-        <SignIn signIn={props.signIn} signInError={props.signInError} />
-    ).dive();
-
-    const newUsername = 'bar';
-
-    expect(wrapper.state().username).toEqual('');
-    wrapper.instance().updateUsername(newUsername);
-    expect(wrapper.state().username).toEqual(newUsername);
-});
-
 test('display error message if there is a `signInError`', () => {
     const wrapper = shallow(
         <SignIn signIn={props.signIn} signInError={props.signInError} />

--- a/packages/venia-concept/src/components/SignIn/signIn.js
+++ b/packages/venia-concept/src/components/SignIn/signIn.js
@@ -1,11 +1,17 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import get from 'lodash/get';
 import Input from 'src/components/Input';
 import Button from 'src/components/Button';
 import defaultClasses from './signIn.css';
 import classify from 'src/classify';
 import { Form } from 'informed';
 import ErrorDisplay from 'src/components/ErrorDisplay';
+
+const fields = {
+    username: 'username',
+    password: 'password'
+};
 
 class SignIn extends Component {
     static propTypes = {
@@ -17,44 +23,48 @@ class SignIn extends Component {
             signInError: PropTypes.string,
             showCreateAccountButton: PropTypes.string
         }),
-
         signInError: PropTypes.object,
         signIn: PropTypes.func
     };
 
-    state = {
-        password: '',
-        username: ''
-    };
+    constructor(props) {
+        super(props);
+        this.formState = {};
+    }
 
     get errorMessage() {
         const { signInError } = this.props;
         return <ErrorDisplay error={signInError} />;
     }
 
+    getFieldValue = field => get(this.formState, `values.${field}`, '');
+
+    handleFormState = formState => {
+        this.formState = formState;
+    };
+
     render() {
         const { classes } = this.props;
         const { onSignIn, errorMessage } = this;
+        const { username, password } = fields;
 
         return (
             <div className={classes.root}>
-                <Form onSubmit={onSignIn}>
+                <Form onSubmit={onSignIn} onChange={this.handleFormState}>
                     <Input
-                        onChange={this.updateUsername}
                         helpText={'example help text'}
                         label={'Username or Email'}
-                        required={true}
+                        required
                         autoComplete={'username'}
-                        field="username"
+                        field={username}
                     />
                     <Input
-                        onChange={this.updatePassword}
                         label={'Password'}
                         type={'password'}
                         helpText={'example help text'}
-                        required={true}
+                        required
                         autoComplete={'current-password'}
-                        field="password"
+                        field={password}
                     />
                     <div className={classes.signInButton}>
                         <Button type="submit">Sign In</Button>
@@ -76,21 +86,14 @@ class SignIn extends Component {
     }
 
     onSignIn = () => {
-        const { username, password } = this.state;
-        this.props.signIn({ username: username, password: password });
+        const username = this.getFieldValue(fields.username);
+        const password = this.getFieldValue(fields.password);
+        this.props.signIn({ username, password });
     };
 
     showCreateAccountForm = () => {
-        this.props.setDefaultUsername(this.state.username);
+        this.props.setDefaultUsername(this.getFieldValue(fields.username));
         this.props.showCreateAccountForm();
-    };
-
-    updatePassword = newPassword => {
-        this.setState({ password: newPassword });
-    };
-
-    updateUsername = newUsername => {
-        this.setState({ username: newUsername });
     };
 }
 

--- a/packages/venia-concept/src/reducers/checkout.js
+++ b/packages/venia-concept/src/reducers/checkout.js
@@ -7,7 +7,9 @@ export const name = 'checkout';
 const initialState = {
     editing: null,
     step: 'cart',
-    submitting: false
+    submitting: false,
+    isAddressIncorrect: false,
+    incorrectAddressMessage: ''
 };
 
 const reducerMap = {
@@ -35,13 +37,28 @@ const reducerMap = {
             ...state,
             editing: null,
             step: 'form',
-            submitting: false
+            submitting: false,
+            isAddressIncorrect: false,
+            incorrectAddressMessage: ''
+        };
+    },
+    [actions.input.incorrectAddress]: (
+        state,
+        { payload: { incorrectAddressMessage } }
+    ) => {
+        return {
+            ...state,
+            submitting: false,
+            isAddressIncorrect: true,
+            incorrectAddressMessage
         };
     },
     [actions.input.reject]: state => {
         return {
             ...state,
-            submitting: false
+            submitting: false,
+            isAddressIncorrect: false,
+            incorrectAddressMessage: ''
         };
     },
     [actions.order.submit]: state => {


### PR DESCRIPTION
Update Input component, address form from the checkout, add validation for the state field

<!-- (REQUIRED) What is the nature of this PR? -->

## This PR is a:

[ ] New feature
[ ] Enhancement/Optimization
[ X ] Refactor
[ ] Bugfix
[ ] Test for existing code
[ ] Documentation

Add validation block to the address form and show details about invalid address form fulfilling there.

## Summary

When this pull request is merged, it will fix issue with saving address in checkout https://github.com/magento-research/pwa-studio/issues/462 and Common Input does not handle initial value correctly https://github.com/magento-research/pwa-studio/issues/416

<!-- (OPTIONAL) What other information can you provide about this PR? -->

## Additional information

<!--
Thank you for your contribution!

Before submitting this pull request, please make sure you have read our Contribution Guidelines and your PR meets our contribution standards:
https://github.com/magento-research/pwa-studio/blob/master/.github/CONTRIBUTION.md

Please fill out as much information as you can about your PR to help speed up the review process.
If your PR addresses an existing GitHub Issue, please refer to it in the title or Additional Information section to make the connection.

We may ask you for changes in your PR in order to meet the standards set in our Contribution Guidelines. PR's that do not comply with our guidelines may be closed at the maintainers' discretion.

Feel free to remove this section before creating this PR.
-->
