### PR TITLE
Fix tests by mocking virtual module

### DIFF
--- a/packages/venia-concept/__mocks__/virtualModule.js
+++ b/packages/venia-concept/__mocks__/virtualModule.js
@@ -1,0 +1,1 @@
+module.exports = jest.fn();

--- a/packages/venia-concept/jest.config.js
+++ b/packages/venia-concept/jest.config.js
@@ -5,6 +5,10 @@ module.exports = {
     browser: true,
     testURL: 'https://localhost/',
     moduleNameMapper: {
+        // Peregrine imports a virtual module that must be mocked.
+        // It would be nice if Venia respected a mock in Peregrine,
+        // but it doesn't, so Venia tests will fail without this.
+        '^FETCH_ROOT_COMPONENT$': '<rootDir>/__mocks__/virtualModule.js',
         '\\.css$': 'identity-obj-proxy',
         // Mirrors webpack alias to resolve from 'src'
         '^src/(.+)': '<rootDir>/src/$1',


### PR DESCRIPTION
`FETCH_ROOT_COMPONENT` is a virtual module, so Peregrine should mock it for tests. But Venia doesn't respect Peregrine's mocks, so its own tests will fail if they don't also mock the module.

So I'm mocking this module in Venia until we have a better solution.

<!-- (REQUIRED) What is the nature of this PR? -->

## This PR is a:

- [ ] New feature
- [ ] Enhancement/Optimization
- [ ] Refactor
- [x] Bugfix
- [x] Test for existing code
- [ ] Documentation

## Summary

When this pull request is merged, it will make tests pass again.