### PR TITLE
GH #519 fix Invision links in Venia design topics

### DIFF
--- a/pwa-devdocs/src/venia-pwa-concept/design/category-page/index.md
+++ b/pwa-devdocs/src/venia-pwa-concept/design/category-page/index.md
@@ -7,6 +7,10 @@ title: Category page
 This design specification is still in development.
 If have any feedback or would like to join the PWA conversation, please join our [Slack][] channel.
 
+## Layout
+
+See the [interactive mockup][] for a preview of the homepage layout.
+
 ## Page states
 
 The category page handles the following [Page][] states:
@@ -45,6 +49,8 @@ The following table shows a visual breakdown of these components.
 
 [Header]: {{ site.baseurl }}{% link venia-pwa-concept/component/header/index.md %}
 [Header image]: {{ site.baseurl }}{% link venia-pwa-concept/images/header-menu-collapsed-with-cart-item.png %}
+
+[interactive mockup]: https://magento.invisionapp.com/share/WQN5F7BYBPG#/screens/310613672
 
 [Title bar image]: {{ site.baseurl }}{% link venia-pwa-concept/images/title-bar-dresses.png %}
 [Title bar]: {{ site.baseurl }}{% link venia-pwa-concept/component/title-bar/index.md %} 

--- a/pwa-devdocs/src/venia-pwa-concept/design/homepage/index.md
+++ b/pwa-devdocs/src/venia-pwa-concept/design/homepage/index.md
@@ -49,7 +49,7 @@ The following table shows a visual breakdown of these components.
 {:style="table-layout:auto"}
 
 
-[interactive mockup]: https://magento.invisionapp.com/share/5YMQJXACV6A#/screens
+[interactive mockup]: https://magento.invisionapp.com/share/WQN5F7BYBPG#/screens/310613558
 
 [Header]: {{ site.baseurl }}{% link venia-pwa-concept/component/header/index.md %}
 [Header image]: {{ site.baseurl }}{% link venia-pwa-concept/images/header-menu-with-search.png %}

--- a/pwa-devdocs/src/venia-pwa-concept/design/product-page/index.md
+++ b/pwa-devdocs/src/venia-pwa-concept/design/product-page/index.md
@@ -60,7 +60,7 @@ The following table shows a visual breakdown of these components.
 
 
 [Product page]: {{ site.baseurl }}{% link venia-pwa-concept/images/PD-docs-preview.jpg %}
-[interactive mockup]: https://magento.invisionapp.com/share/FVK8N2XAX7Q#/screens
+[interactive mockup]: https://magento.invisionapp.com/share/WQN5F7BYBPG#/screens/322904233
 
 [Page image]: {{ site.baseurl }}{% link venia-pwa-concept/images/offline-notification-bar.png %}
 [Page]: {{ site.baseurl }}{% link venia-pwa-concept/component/page/index.md %}


### PR DESCRIPTION
<!-- (REQUIRED) What is the nature of this PR? -->

## This PR is a:

[ ] New feature
[ ] Enhancement/Optimization
[ ] Refactor
[ ] Bugfix
[ ] Test for existing code
[X] Documentation

<!-- (REQUIRED) What does this PR change? -->

## Summary

When this pull request is merged, it will fix the broken Invision links in the Venia design topic pages.

<!-- (OPTIONAL) What other information can you provide about this PR? -->

## Additional information

This PR closes #519 