### PR TITLE
Fixed MAGENTO_BACKEND_URL

### DIFF
--- a/packages/venia-concept/.env.dist
+++ b/packages/venia-concept/.env.dist
@@ -15,7 +15,7 @@
 #
 #   Connect to an instance of Magento 2.3 by specifying its public
 #   domain name. **REQUIRED.** Example:
-MAGENTO_BACKEND_URL="https://venia.release-dev-rxvv2iq-zddsyhrdimyra.us-4.magentosite.cloud/"
+MAGENTO_BACKEND_URL="https://release-dev-rxvv2iq-zddsyhrdimyra.us-4.magentosite.cloud/"
 #
 #   Use a particular website code when making API calls. Defaults to 'base',
 #   but for your PWA to act as a different "website" in the Magento admin,


### PR DESCRIPTION
Updated MAGENTO_BACKEND_URL to Magento Back-End URL instead of Front-End URL

<!-- (REQUIRED) What is the nature of this PR? -->

## This PR is a:

[ ] New feature
[ ] Enhancement/Optimization
[ ] Refactor
[x] Bugfix
[ ] Test for existing code
[ ] Documentation

<!-- (REQUIRED) What does this PR change? -->

## Summary

When this pull request is merged, it will make the Venia theme work with the demo Magento Back-End

<!--
Thank you for your contribution!

Before submitting this pull request, please make sure you have read our Contribution Guidelines and your PR meets our contribution standards:
https://github.com/magento-research/pwa-studio/blob/master/.github/CONTRIBUTION.md

Please fill out as much information as you can about your PR to help speed up the review process.
If your PR addresses an existing GitHub Issue, please refer to it in the title or Additional Information section to make the connection.

We may ask you for changes in your PR in order to meet the standards set in our Contribution Guidelines. PR's that do not comply with our guidelines may be closed at the maintainers' discretion.

Feel free to remove this section before creating this PR.
-->
