### PR TITLE
Add labels to buttons on main, categories and product details pages

### DIFF
--- a/packages/venia-concept/src/components/Pagination/constants.js
+++ b/packages/venia-concept/src/components/Pagination/constants.js
@@ -1,0 +1,18 @@
+export const navButtons = {
+    firstPage: {
+        name: 'rewind',
+        buttonLabel: 'move to the first page'
+    },
+    prevPage: {
+        name: 'chevron-left',
+        buttonLabel: 'move to the previous page'
+    },
+    nextPage: {
+        name: 'chevron-right',
+        buttonLabel: 'move to the next page'
+    },
+    lastPage: {
+        name: 'fast-forward',
+        buttonLabel: 'move to the last page'
+    }
+};

--- a/packages/venia-concept/src/components/Pagination/navButton.js
+++ b/packages/venia-concept/src/components/Pagination/navButton.js
@@ -17,8 +17,12 @@ const inactiveFill = {
 };
 
 class NavButton extends Component {
+    static defaultProps = {
+        buttonLabel: 'move to another page'
+    };
+
     render() {
-        const { classes, name, active, onClick } = this.props;
+        const { classes, name, active, onClick, buttonLabel } = this.props;
         let attrs;
         // The chevron icon does not have a fill or any sizing issues that
         // need to be handled with attributes in props
@@ -33,7 +37,11 @@ class NavButton extends Component {
         const className = active ? classes.buttonArrow : classes.buttonInactive;
 
         return (
-            <button className={className} onClick={onClick}>
+            <button
+                className={className}
+                aria-label={buttonLabel}
+                onClick={onClick}
+            >
                 <Icon name={name} attrs={attrs} />
             </button>
         );

--- a/packages/venia-concept/src/components/Pagination/pagination.js
+++ b/packages/venia-concept/src/components/Pagination/pagination.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import classify from 'src/classify';
 import defaultClasses from './pagination.css';
 import NavButton from './navButton';
+import { navButtons } from './constants';
 
 const tileBuffer = 2;
 
@@ -72,25 +73,29 @@ class Pagination extends Component {
         return (
             <div className={classes.root}>
                 <NavButton
-                    name="rewind"
+                    name={navButtons.firstPage.name}
                     active={isActiveLeft}
                     onClick={() => this.setPage(leftSkip)}
+                    buttonLabel={navButtons.firstPage.buttonLabel}
                 />
                 <NavButton
-                    name="chevron-left"
+                    name={navButtons.prevPage.name}
                     active={isActiveLeft}
                     onClick={this.slideNavLeft}
+                    buttonLabel={navButtons.prevPage.buttonLabel}
                 />
                 {navigationTiles}
                 <NavButton
-                    name="chevron-right"
+                    name={navButtons.nextPage.name}
                     active={isActiveRight}
                     onClick={this.slideNavRight}
+                    buttonLabel={navButtons.nextPage.buttonLabel}
                 />
                 <NavButton
-                    name="fast-forward"
+                    name={navButtons.lastPage.name}
                     active={isActiveRight}
                     onClick={() => this.setPage(rightSkip)}
+                    buttonLabel={navButtons.lastPage.buttonLabel}
                 />
             </div>
         );

--- a/packages/venia-concept/src/components/ProductQuantity/quantity.js
+++ b/packages/venia-concept/src/components/ProductQuantity/quantity.js
@@ -18,12 +18,21 @@ class Quantity extends Component {
         )
     };
 
+    static defaultProps = {
+        selectLabel: "product's quantity"
+    };
+
     render() {
-        const { classes, ...restProps } = this.props;
+        const { classes, selectLabel, ...restProps } = this.props;
 
         return (
             <div className={classes.root}>
-                <Select {...restProps} field="quantity" items={mockData} />
+                <Select
+                    {...restProps}
+                    field="quantity"
+                    aria-label={selectLabel}
+                    items={mockData}
+                />
             </div>
         );
     }


### PR DESCRIPTION
<!-- (REQUIRED) What is the nature of this PR? -->

## This PR is a:

- [ ] New feature
- [ ] Enhancement/Optimization
- [ ] Refactor
- [ ] Bugfix
- [ ] Test for existing code
- [ ] Documentation

<!-- (REQUIRED) What does this PR change? -->

## Summary

When this pull request is merged, it will add labels to buttons on main page, categories page, product details page to elevate accessibility of the application

<!-- (OPTIONAL) What other information can you provide about this PR? -->

## Additional information

<!--
Thank you for your contribution!

Before submitting this pull request, please make sure you have read our Contribution Guidelines and your PR meets our contribution standards:
https://github.com/magento-research/pwa-studio/blob/master/.github/CONTRIBUTION.md

Please fill out as much information as you can about your PR to help speed up the review process.
If your PR addresses an existing GitHub Issue, please refer to it in the title or Additional Information section to make the connection.

We may ask you for changes in your PR in order to meet the standards set in our Contribution Guidelines. PRs that do not comply with our guidelines may be closed at the maintainers' discretion.

Feel free to remove this section before creating this PR.
-->
