### PR TITLE
[TASK] Display the Last Real Order ID in the Receipt

### DIFF
--- a/packages/venia-concept/src/components/Checkout/Receipt/receipt.js
+++ b/packages/venia-concept/src/components/Checkout/Receipt/receipt.js
@@ -3,6 +3,8 @@ import { func, shape, string } from 'prop-types';
 import classify from 'src/classify';
 import Button, { darkThemeClasses } from 'src/components/Button';
 import defaultClasses from './receipt.css';
+import currentSessionLastOrderQuery from "../../../queries/getCurrentSessionLastOrder.graphql";
+import {Query} from "react-apollo";
 
 export const CONTINUE_SHOPPING_BUTTON_ID = 'continue-shopping-button';
 export const CREATE_ACCOUNT_BUTTON_ID = 'create-account-button';
@@ -55,7 +57,37 @@ class Receipt extends Component {
                     </h2>
                     <div className={classes.textBlock}>
                         Your order # is{' '}
-                        <span className={classes.orderId}>{id}</span>
+                        <Query query={currentSessionLastOrderQuery}>
+                            {({ loading, error, data }) => {
+                                if (error) {
+                                    return (
+                                        <span className={classes.fetchError}>
+                                            Data Fetch Error: <pre>{error.message}</pre>
+                                        </span>
+                                    );
+                                }
+                                if (loading) {
+                                    return (
+                                        <span className={classes.fetchingData}>
+                                            Fetching Data
+                                        </span>
+                                    );
+                                }
+                                if (data.currentSessionLastOrder.increment_id === null) {
+                                    return (
+                                        <div className={classes.noResults}>
+                                            Order data unavailable
+                                        </div>
+                                    );
+                                }
+
+                                return (
+                                    <span className={classes.orderId}>
+                                        {data.currentSessionLastOrder.increment_id}
+                                    </span>
+                                );
+                            }}
+                        </Query>
                         <br />
                         We&rsquo;ll email you an order confirmation with details
                         and tracking info

--- a/packages/venia-concept/src/queries/getCurrentSessionLastOrder.graphql
+++ b/packages/venia-concept/src/queries/getCurrentSessionLastOrder.graphql
@@ -1,0 +1,7 @@
+# TODO: get only active categories from graphql when it is ready
+query currentSessionLastOrder {
+    currentSessionLastOrder {
+        id
+        increment_id
+    }
+}


### PR DESCRIPTION
<!-- (REQUIRED) What is the nature of this PR? -->
When you place an order it should return the Increment Id and not the entity id

### Before changes
![image](https://user-images.githubusercontent.com/6040343/49823697-9909d600-fd80-11e8-917c-ce43535ad9b0.png)

## This PR is a:

- [ ] New feature
- [ ] Enhancement/Optimization
- [ ] Refactor
- [ ] Bugfix
- [ ] Test for existing code
- [ ] Documentation

<!-- (REQUIRED) What does this PR change? -->

## Summary

When this pull request is merged, it will...

<!-- (OPTIONAL) What other information can you provide about this PR? -->
### After Changes
![image](https://user-images.githubusercontent.com/6040343/49823645-7a0b4400-fd80-11e8-95fd-87eae819fd22.png)

## Additional information
Related PR https://github.com/magento/graphql-ce/pull/298

<!--
Thank you for your contribution!

Before submitting this pull request, please make sure you have read our Contribution Guidelines and your PR meets our contribution standards:
https://github.com/magento-research/pwa-studio/blob/master/.github/CONTRIBUTION.md

Please fill out as much information as you can about your PR to help speed up the review process.
If your PR addresses an existing GitHub Issue, please refer to it in the title or Additional Information section to make the connection.

We may ask you for changes in your PR in order to meet the standards set in our Contribution Guidelines. PRs that do not comply with our guidelines may be closed at the maintainers' discretion.

Feel free to remove this section before creating this PR.
-->
