### PR TITLE
Removes calls to configure adapter from individual test files

### DIFF
--- a/packages/venia-concept/src/RootComponents/Category/__tests__/categoryContent.spec.js
+++ b/packages/venia-concept/src/RootComponents/Category/__tests__/categoryContent.spec.js
@@ -1,10 +1,7 @@
 import React from 'react';
-import { configure, shallow } from 'enzyme';
-import Adapter from 'enzyme-adapter-react-16';
+import { shallow } from 'enzyme';
 
 import CategoryContent from '../categoryContent';
-
-configure({ adapter: new Adapter() });
 
 const classes = {
     root: 'a',

--- a/packages/venia-concept/src/components/CategoryList/__tests__/categoryList.spec.js
+++ b/packages/venia-concept/src/components/CategoryList/__tests__/categoryList.spec.js
@@ -1,15 +1,12 @@
 jest.mock('../../../classify');
 import React from 'react';
 import wait from 'waait';
-import { configure, mount } from 'enzyme';
-import Adapter from 'enzyme-adapter-react-16';
+import { mount } from 'enzyme';
 import { MemoryRouter } from 'react-router-dom';
 import { MockedProvider } from 'react-apollo/test-utils';
 import CategoryTile from '../categoryTile';
 import CategoryList from '../categoryList';
 import getCategoryList from '../../../queries/getCategoryList.graphql';
-
-configure({ adapter: new Adapter() });
 
 const withRouterAndApolloClient = (mocks, renderFn) => (
     <MemoryRouter initialIndex={0} initialEntries={['/']}>

--- a/packages/venia-concept/src/components/ForgotPassword/ForgotPasswordForm/__tests__/forgotPasswordForm.spec.js
+++ b/packages/venia-concept/src/components/ForgotPassword/ForgotPasswordForm/__tests__/forgotPasswordForm.spec.js
@@ -1,12 +1,9 @@
 import React from 'react';
-import { configure, shallow } from 'enzyme';
+import { shallow } from 'enzyme';
 import { Form } from 'informed';
-import Adapter from 'enzyme-adapter-react-16';
 
 import Button from 'src/components/Button';
 import ForgotPasswordForm from '../forgotPasswordForm';
-
-configure({ adapter: new Adapter() });
 
 test('renders correctly', () => {
     const emailInputProps = { field: 'email' };

--- a/packages/venia-concept/src/components/ForgotPassword/FormSubmissionSuccessful/__tests__/formSubmissionSuccessful.spec.js
+++ b/packages/venia-concept/src/components/ForgotPassword/FormSubmissionSuccessful/__tests__/formSubmissionSuccessful.spec.js
@@ -1,11 +1,8 @@
 import React from 'react';
-import { configure, shallow } from 'enzyme';
-import Adapter from 'enzyme-adapter-react-16';
+import { shallow } from 'enzyme';
 
 import Button from 'src/components/Button';
 import FormSubmissionSuccessful from '../formSubmissionSuccessful';
-
-configure({ adapter: new Adapter() });
 
 const classes = {
     text: 'text'

--- a/packages/venia-concept/src/components/MiniCart/__tests__/section.spec.js
+++ b/packages/venia-concept/src/components/MiniCart/__tests__/section.spec.js
@@ -1,10 +1,7 @@
 import React from 'react';
-import { configure, shallow } from 'enzyme';
-import Adapter from 'enzyme-adapter-react-16';
+import { shallow } from 'enzyme';
 
 import Section from '../section';
-
-configure({ adapter: new Adapter() });
 
 const classes = { text: 'a' };
 

--- a/packages/venia-concept/src/components/Navigation/__tests__/categoryTree.spec.js
+++ b/packages/venia-concept/src/components/Navigation/__tests__/categoryTree.spec.js
@@ -6,7 +6,6 @@ import navigationMenuQuery from '../../../queries/getNavigationMenu.graphql';
 import { MockedProvider } from 'react-apollo/test-utils';
 import CategoryTree from '../categoryTree';
 
-
 jest.mock('react-router-dom/Link', () => () => <h6>link</h6>);
 jest.mock('react-router-dom/NavLink', () => 'navlink');
 

--- a/packages/venia-concept/src/components/Navigation/__tests__/categoryTree.spec.js
+++ b/packages/venia-concept/src/components/Navigation/__tests__/categoryTree.spec.js
@@ -1,12 +1,11 @@
 import React from 'react';
 import wait from 'waait';
-import { configure, mount } from 'enzyme';
-import Adapter from 'enzyme-adapter-react-16';
+import { mount } from 'enzyme';
+
 import navigationMenuQuery from '../../../queries/getNavigationMenu.graphql';
 import { MockedProvider } from 'react-apollo/test-utils';
 import CategoryTree from '../categoryTree';
 
-configure({ adapter: new Adapter() });
 
 jest.mock('react-router-dom/Link', () => () => <h6>link</h6>);
 jest.mock('react-router-dom/NavLink', () => 'navlink');

--- a/packages/venia-concept/src/components/Navigation/__tests__/navigation.spec.js
+++ b/packages/venia-concept/src/components/Navigation/__tests__/navigation.spec.js
@@ -1,9 +1,6 @@
 import React from 'react';
-import { configure, shallow } from 'enzyme';
-import Adapter from 'enzyme-adapter-react-16';
+import { shallow } from 'enzyme';
 import Navigation from '../navigation';
-
-configure({ adapter: new Adapter() });
 
 test('getUserDetails() should be called when navigation component mounts', async () => {
     const getUserDetails = jest.fn();

--- a/packages/venia-concept/src/components/Pagination/__tests__/pagination.spec.js
+++ b/packages/venia-concept/src/components/Pagination/__tests__/pagination.spec.js
@@ -1,10 +1,7 @@
 import React from 'react';
-import { configure, shallow, mount } from 'enzyme';
-import Adapter from 'enzyme-adapter-react-16';
+import { shallow, mount } from 'enzyme';
 
 import Pagination from '../pagination';
-
-configure({ adapter: new Adapter() });
 
 const classes = { root: 'a' };
 


### PR DESCRIPTION
<!-- (REQUIRED) What is the nature of this PR? -->

## This PR is a:

- [ ] New feature
- [ ] Enhancement/Optimization
- [x] Refactor
- [ ] Bugfix
- [ ] Test for existing code
- [ ] Documentation

<!-- (REQUIRED) What does this PR change? -->

## Summary

When this pull request is merged, it will remove calls to `configure` the Enzyme adapter from individual tests. #602 moves this configuration to the Jest setup file, so individual test files no longer need to do this.

<!-- (OPTIONAL) What other information can you provide about this PR? -->

## Additional information

n/a

<!--
Thank you for your contribution!

Before submitting this pull request, please make sure you have read our Contribution Guidelines and your PR meets our contribution standards:
https://github.com/magento-research/pwa-studio/blob/master/.github/CONTRIBUTION.md

Please fill out as much information as you can about your PR to help speed up the review process.
If your PR addresses an existing GitHub Issue, please refer to it in the title or Additional Information section to make the connection.

We may ask you for changes in your PR in order to meet the standards set in our Contribution Guidelines. PRs that do not comply with our guidelines may be closed at the maintainers' discretion.

Feel free to remove this section before creating this PR.
-->
