### PR TITLE
Fix relative path module resolution of tape

### DIFF
--- a/packages/upward-spec/bin/upward-spec
+++ b/packages/upward-spec/bin/upward-spec
@@ -39,8 +39,12 @@ const raw = useTap || isPiped;
 
 // Run tap and pass stdout.
 const scenariosDir = path.resolve(__dirname, '../suite/scenarios/');
+const tapePath = path.resolve(
+    path.dirname(require.resolve('tape')),
+    './bin/tape'
+);
 const testProcess = require('child_process').spawn(
-    path.resolve(__dirname, '../node_modules/.bin/tape'),
+    tapePath,
     ['*/tests.js'],
     {
         cwd: scenariosDir,


### PR DESCRIPTION
<!-- (REQUIRED) What is the nature of this PR? -->

## This PR is a: bugfix for `upward-spec` that allows modules outside of the monorepo to execute the test suite, and correctly resolve the module dependency `tape`.

- [ ] New feature
- [ ] Enhancement/Optimization
- [ ] Refactor
- [x] Bugfix
- [ ] Test for existing code
- [ ] Documentation

<!-- (REQUIRED) What does this PR change? -->

## Summary

When this pull request is merged, it will...

<!-- (OPTIONAL) What other information can you provide about this PR? -->

## Additional information

<!--
Thank you for your contribution!

Before submitting this pull request, please make sure you have read our Contribution Guidelines and your PR meets our contribution standards:
https://github.com/magento-research/pwa-studio/blob/master/.github/CONTRIBUTION.md

Please fill out as much information as you can about your PR to help speed up the review process.
If your PR addresses an existing GitHub Issue, please refer to it in the title or Additional Information section to make the connection.

We may ask you for changes in your PR in order to meet the standards set in our Contribution Guidelines. PRs that do not comply with our guidelines may be closed at the maintainers' discretion.

Feel free to remove this section before creating this PR.
-->
