### PR TITLE
Fixed an issue where autocomplete popup wouldn't close on search submit

### DIFF
--- a/packages/venia-concept/src/components/SearchBar/searchBar.js
+++ b/packages/venia-concept/src/components/SearchBar/searchBar.js
@@ -98,8 +98,10 @@ export class SearchBar extends Component {
     handleInputChange = () => this.updateAutocompleteVisible(true);
 
     handleSubmit = ({ search_query }) => {
-        search_query &&
+        if (search_query) {
             this.props.executeSearch(search_query, this.props.history);
+            this.updateAutocompleteVisible(false);
+        }
     };
 
     resetForm = () => {


### PR DESCRIPTION
<!-- (REQUIRED) What is the nature of this PR? -->

## This PR is a:

- [ ] New feature
- [ ] Enhancement/Optimization
- [ ] Refactor
- [x] Bugfix
- [ ] Test for existing code
- [ ] Documentation

<!-- (REQUIRED) What does this PR change? -->

## Summary

When this pull request is merged, it will fix an issue where autocomplete popup doesn't close when search form is submitted by pressing the "Enter" key.

Reported here by @supernova-at : https://github.com/magento-research/pwa-studio/pull/548#issuecomment-451302270

<!-- (OPTIONAL) What other information can you provide about this PR? -->

## Additional information

n/a

<!--
Thank you for your contribution!

Before submitting this pull request, please make sure you have read our Contribution Guidelines and your PR meets our contribution standards:
https://github.com/magento-research/pwa-studio/blob/master/.github/CONTRIBUTION.md

Please fill out as much information as you can about your PR to help speed up the review process.
If your PR addresses an existing GitHub Issue, please refer to it in the title or Additional Information section to make the connection.

We may ask you for changes in your PR in order to meet the standards set in our Contribution Guidelines. PRs that do not comply with our guidelines may be closed at the maintainers' discretion.

Feel free to remove this section before creating this PR.
-->
