### PR TITLE
Replace waait with wait-for-expect

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20438,12 +20438,6 @@
 				"browser-process-hrtime": "^0.1.2"
 			}
 		},
-		"waait": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/waait/-/waait-1.0.2.tgz",
-			"integrity": "sha512-amvD7uRx48U2gXOgzwV7PbcpSy8O3Fect2SqiLbBIVH9Zh0UMnDWckSLnsdKNwq7pvarWnPWrpYad2P3pgmRYw==",
-			"dev": true
-		},
 		"wait-for-expect": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/wait-for-expect/-/wait-for-expect-1.1.0.tgz",
@@ -20731,6 +20725,12 @@
 				"ws": "^6.0.0"
 			},
 			"dependencies": {
+				"acorn": {
+					"version": "5.7.3",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
+					"integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==",
+					"dev": true
+				},
 				"filesize": {
 					"version": "3.6.1",
 					"resolved": "https://registry.npmjs.org/filesize/-/filesize-3.6.1.tgz",

--- a/package.json
+++ b/package.json
@@ -145,7 +145,6 @@
     "tape": "~4.9.1",
     "terser": "~3.8.2",
     "terser-webpack-plugin": "~1.1.0",
-    "waait": "~1.0.2",
     "wait-for-expect": "^1.1.0",
     "webpack": "~4.25.1",
     "webpack-babel-env-deps": "~1.4.3",

--- a/packages/venia-concept/src/components/CategoryList/__tests__/categoryList.spec.js
+++ b/packages/venia-concept/src/components/CategoryList/__tests__/categoryList.spec.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import wait from 'waait';
+import waitForExpect from 'wait-for-expect';
 import TestRenderer from 'react-test-renderer';
 import { MemoryRouter } from 'react-router-dom';
 import { MockedProvider } from 'react-apollo/test-utils';
@@ -115,7 +115,7 @@ test('renders category tiles', async () => {
 
     expect(root.findByType(LoadingIndicator)).toBeTruthy();
 
-    await wait();
-
-    expect(root.findAllByType(CategoryTile)).toHaveLength(3);
+    await waitForExpect(() => {
+        expect(root.findAllByType(CategoryTile)).toHaveLength(3);
+    });
 });

--- a/packages/venia-concept/src/components/CreateAccount/__tests__/createAccount.spec.js
+++ b/packages/venia-concept/src/components/CreateAccount/__tests__/createAccount.spec.js
@@ -1,6 +1,6 @@
 import React from 'react';
+import waitForExpect from 'wait-for-expect';
 import TestRenderer from 'react-test-renderer';
-import wait from 'waait';
 import { Form } from 'informed';
 
 import CreateAccount from '../createAccount';
@@ -46,14 +46,14 @@ test('executes validators on submit', async () => {
     // touch fields, call validators, call onSubmit
     api.submitForm();
     // await async validation
-    await wait(0);
-
-    for (const validator of validators.values()) {
-        expect(validator).toHaveBeenCalledTimes(1);
-    }
-    for (const validator of asyncValidators.values()) {
-        expect(validator).toHaveBeenCalledTimes(1);
-    }
+    await waitForExpect(() => {
+        for (const validator of validators.values()) {
+            expect(validator).toHaveBeenCalledTimes(1);
+        }
+        for (const validator of asyncValidators.values()) {
+            expect(validator).toHaveBeenCalledTimes(1);
+        }
+    });
 });
 
 test('calls onSubmit if validation passes', async () => {
@@ -67,11 +67,11 @@ test('calls onSubmit if validation passes', async () => {
     // touch fields, call validators, call onSubmit
     api.submitForm();
     // await async validation
-    await wait(0);
+    await waitForExpect(() => {
+        const { asyncErrors, errors } = form.instance.controller.state;
 
-    const { asyncErrors, errors } = form.instance.controller.state;
-
-    expect(Object.keys(asyncErrors)).toHaveLength(0);
-    expect(Object.keys(errors)).toHaveLength(0);
-    expect(submitCallback).toHaveBeenCalledTimes(1);
+        expect(Object.keys(asyncErrors)).toHaveLength(0);
+        expect(Object.keys(errors)).toHaveLength(0);
+        expect(submitCallback).toHaveBeenCalledTimes(1);
+    });
 });

--- a/packages/venia-concept/src/components/Navigation/__tests__/categoryTree.spec.js
+++ b/packages/venia-concept/src/components/Navigation/__tests__/categoryTree.spec.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import wait from 'waait';
 import waitForExpect from 'wait-for-expect';
 import TestRenderer from 'react-test-renderer';
 import { MemoryRouter } from 'react-router-dom';
@@ -178,12 +177,12 @@ test('child node correctly sets new root and parent ids', async () => {
         </MockedProvider>
     );
 
-    await wait();
+    await waitForExpect(() => {
+        const child = root.findByProps({ path: '1/3' });
+        const { onDive, path } = child.props;
 
-    const child = root.findByProps({ path: '1/3' });
-    const { onDive, path } = child.props;
+        onDive(path);
 
-    onDive(path);
-
-    expect(setCurrentPath).toHaveBeenLastCalledWith(path);
+        expect(setCurrentPath).toHaveBeenLastCalledWith(path);
+    });
 });


### PR DESCRIPTION
## This PR is a:

- [ ] New feature
- [ ] Enhancement/Optimization
- [ ] Refactor
- [x] Bugfix
- [x] Test for existing code
- [ ] Documentation

## Summary

When this pull request is merged, it will replace all instances of `waait` with `wait-for-expect`. This will fix flaky tests.