### PR TITLE
Revert "Corrects a spelling mistake in Peregrine documentation"

### DIFF
--- a/packages/pwa-devdocs/src/peregrine/reference/rest-api-client/index.md
+++ b/packages/pwa-devdocs/src/peregrine/reference/rest-api-client/index.md
@@ -191,7 +191,7 @@ function placeCancelable(emitter) {
 
 `getResponse()`
 
-: Get the promise for the network operation.
+: Get the promise for the network operarion.
   This method can only be called after `run()` executes.
   This method exists so that requests can reuse the promises from other requests.
 


### PR DESCRIPTION
Reverts magento-research/pwa-studio#754 because it went into `master` instead of `release/2.0`.