### PR TITLE
Category pagination fix

### DIFF
--- a/packages/peregrine/src/index.js
+++ b/packages/peregrine/src/index.js
@@ -5,6 +5,6 @@ export { default as ContainerChild } from './ContainerChild';
 export { default as List, Items, Item } from './List';
 export { default as Page } from './Page';
 export { default as Price } from './Price';
-export { default as Router } from './Router';
+export { default as Router , RouteConsumer } from './Router';
 export { RestApi };
 export { Util };

--- a/packages/peregrine/src/index.js
+++ b/packages/peregrine/src/index.js
@@ -5,6 +5,6 @@ export { default as ContainerChild } from './ContainerChild';
 export { default as List, Items, Item } from './List';
 export { default as Page } from './Page';
 export { default as Price } from './Price';
-export { default as Router , RouteConsumer } from './Router';
+export { default as Router, RouteConsumer } from './Router';
 export { RestApi };
 export { Util };

--- a/packages/venia-concept/src/RootComponents/Category/category.js
+++ b/packages/venia-concept/src/RootComponents/Category/category.js
@@ -10,6 +10,7 @@ import { setCurrentPage, setPrevPageTotal } from 'src/actions/catalog';
 import { loadingIndicator } from 'src/components/LoadingIndicator';
 import CategoryContent from './categoryContent';
 import defaultClasses from './category.css';
+import getQueryParameterValue from 'src/util/getQueryParameterValue';
 
 const categoryQuery = gql`
     query category($id: Int!, $pageSize: Int!, $currentPage: Int!) {
@@ -58,16 +59,23 @@ class Category extends Component {
         id: 3
     };
 
+        // gets current page from queryParam
+        getCurrentPage() {
+            const page = getQueryParameterValue({location:undefined,queryParameter:'page'});
+            return page && page <= this.props.prevPageTotal?page:1; 
+        }
+
     render() {
         const {
             id,
             classes,
-            currentPage,
             pageSize,
             prevPageTotal,
             setCurrentPage,
             setPrevPageTotal
         } = this.props;
+
+        const currentPage = this.getCurrentPage();
 
         const pageControl = {
             currentPage: currentPage,

--- a/packages/venia-concept/src/RootComponents/Category/category.js
+++ b/packages/venia-concept/src/RootComponents/Category/category.js
@@ -59,11 +59,14 @@ class Category extends Component {
         id: 3
     };
 
-        // gets current page from queryParam
-        getCurrentPage() {
-            const page = getQueryParameterValue({location:undefined,queryParameter:'page'});
-            return page && page <= this.props.prevPageTotal?page:1; 
-        }
+    // gets current page from queryParam
+    getCurrentPage() {
+        const page = getQueryParameterValue({
+            location: undefined,
+            queryParameter: 'page'
+        });
+        return page && page <= this.props.prevPageTotal ? page : 1;
+    }
 
     render() {
         const {

--- a/packages/venia-concept/src/RootComponents/Category/categoryContent.js
+++ b/packages/venia-concept/src/RootComponents/Category/categoryContent.js
@@ -3,6 +3,7 @@ import classify from 'src/classify';
 import Gallery from 'src/components/Gallery';
 import Pagination from 'src/components/Pagination';
 import defaultClasses from './category.css';
+import { RouteConsumer } from '@magento/peregrine';
 
 class CategoryContent extends Component {
     render() {
@@ -24,7 +25,14 @@ class CategoryContent extends Component {
                     <Gallery data={items} title={title} pageSize={pageSize} />
                 </section>
                 <div className={classes.pagination}>
-                    <Pagination pageControl={pageControl} />
+                <RouteConsumer>
+                        {context => (
+                            <Pagination
+                                pageControl={pageControl}
+                                {...context}
+                            />
+                        )}
+                    </RouteConsumer>
                 </div>
             </article>
         );

--- a/packages/venia-concept/src/RootComponents/Category/categoryContent.js
+++ b/packages/venia-concept/src/RootComponents/Category/categoryContent.js
@@ -25,7 +25,7 @@ class CategoryContent extends Component {
                     <Gallery data={items} title={title} pageSize={pageSize} />
                 </section>
                 <div className={classes.pagination}>
-                <RouteConsumer>
+                    <RouteConsumer>
                         {context => (
                             <Pagination
                                 pageControl={pageControl}

--- a/packages/venia-concept/src/components/Pagination/pagination.js
+++ b/packages/venia-concept/src/components/Pagination/pagination.js
@@ -102,20 +102,27 @@ class Pagination extends Component {
     }
 
     setPage = pageNumber => {
+        if (this.props.history && this.props.location) {
+            const queryParams = new URLSearchParams(this.props.location.search);
+            queryParams.set('page', pageNumber);
+            this.props.history.push({
+                search: queryParams.toString()
+            });
+        }
         this.props.pageControl.setPage(pageNumber);
     };
 
     slideNavLeft = () => {
-        const { setPage, currentPage } = this.props.pageControl;
+        const { currentPage } = this.props.pageControl;
         if (currentPage > 1) {
-            setPage(currentPage - 1);
+            this.setPage(Number(currentPage) - 1);
         }
     };
 
     slideNavRight = () => {
-        const { setPage, currentPage, totalPages } = this.props.pageControl;
+        const { currentPage, totalPages } = this.props.pageControl;
         if (currentPage < totalPages) {
-            setPage(currentPage + 1);
+            this.setPage(Number(currentPage) + 1);
         }
     };
 


### PR DESCRIPTION
<!-- (REQUIRED) What is the nature of this PR? -->

## This PR is a:

- [ ] New feature
- [ ] Enhancement/Optimization
- [ ] Refactor
- [X] Bugfix
- [ ] Test for existing code
- [ ] Documentation

<!-- (REQUIRED) What does this PR change? -->
This PR will fix pagination issue #644
## Summary

When this pull request is merged, it will fix the pagination issue in category page #644 


<!-- (OPTIONAL) What other information can you provide about this PR? -->

## Additional information
- exported RouteConsumer from peregrine router to make use in pagination.
- page will not be reset if the person comes back from PDP.
- when switches category pagination will be reset to 1.
- when a wrong page value is given resets to page 1.

<!--
Thank you for your contribution!

Before submitting this pull request, please make sure you have read our Contribution Guidelines and your PR meets our contribution standards:
https://github.com/magento-research/pwa-studio/blob/master/.github/CONTRIBUTION.md

Please fill out as much information as you can about your PR to help speed up the review process.
If your PR addresses an existing GitHub Issue, please refer to it in the title or Additional Information section to make the connection.

We may ask you for changes in your PR in order to meet the standards set in our Contribution Guidelines. PRs that do not comply with our guidelines may be closed at the maintainers' discretion.

Feel free to remove this section before creating this PR.
-->
