### PR TITLE
Remove pre-push hook for bundlesize

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   ],
   "husky": {
     "hooks": {
-      "pre-push": "npm run prettier && npm run prettier:validate && npm run lint && npm test && npm run build && bundlesize"
+      "pre-push": "npm run prettier && npm run prettier:validate && npm run lint && npm test"
     }
   },
   "devDependencies": {


### PR DESCRIPTION
This removes the pre-push hook that was added in #581.

The CI check is still in place.