### PR TITLE
Apply classnames in Section component

### DIFF
--- a/packages/venia-concept/src/components/Checkout/section.js
+++ b/packages/venia-concept/src/components/Checkout/section.js
@@ -30,7 +30,7 @@ class Section extends Component {
         const icon = selectedOption ? <Icon src={CheckIcon} size={16} /> : null;
 
         return (
-            <button classes={classes.root} {...restProps}>
+            <button className={classes.root} {...restProps}>
                 <span className={classes.content}>
                     <span className={classes.label}>
                         <span>{label}</span>


### PR DESCRIPTION
## This PR is a:

- [ ] New feature
- [ ] Enhancement/Optimization
- [ ] Refactor
- [x] Bugfix
- [ ] Test for existing code
- [ ] Documentation

## Summary

When this pull request is merged, it will fix #772 by properly applying `className` in the `Section` component.