### PR TITLE
[Bug] Handle title and meta tags for navigation on client side

### DIFF
--- a/packages/venia-concept/package.json
+++ b/packages/venia-concept/package.json
@@ -78,6 +78,7 @@
     "react": "~16.6.1",
     "react-apollo": "~2.2.4",
     "react-dom": "~16.6.1",
+    "react-helmet": "^5.2.0",
     "react-redux": "~5.0.7",
     "react-router-dom": "~4.4.0-beta.6",
     "react-test-renderer": "~16.6.1",

--- a/packages/venia-concept/src/RootComponents/Category/category.js
+++ b/packages/venia-concept/src/RootComponents/Category/category.js
@@ -17,6 +17,9 @@ const categoryQuery = gql`
             id
             description
             name
+            meta_title
+            meta_keywords
+            meta_description
             product_count
             products(pageSize: $pageSize, currentPage: $currentPage) {
                 items {

--- a/packages/venia-concept/src/RootComponents/Category/categoryContent.js
+++ b/packages/venia-concept/src/RootComponents/Category/categoryContent.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import HtmlHead from 'src/components/HtmlHead';
 import classify from 'src/classify';
 import Gallery from 'src/components/Gallery';
 import Pagination from 'src/components/Pagination';
@@ -8,18 +9,26 @@ class CategoryContent extends Component {
     render() {
         const { classes, pageControl, data, pageSize } = this.props;
         const items = data ? data.category.products.items : null;
-        const title = data ? data.category.description : null;
+        const title = data ? data.category.name : null;
+        const description = data ? data.category.description : null;
 
         return (
             <article className={classes.root}>
-                <h1 className={classes.title}>
+                <HtmlHead
+                    title={data.category.name}
+                    meta_title={data.category.meta_title}
+                    meta_keywords={data.category.meta_keywords}
+                    meta_description={data.category.meta_description}
+                />
+                <h1 className={classes.title}>{title}</h1>
+                <section>
                     {/* TODO: Switch to RichContent component from Peregrine when merged */}
                     <span
                         dangerouslySetInnerHTML={{
-                            __html: title
+                            __html: description
                         }}
                     />
-                </h1>
+                </section>
                 <section className={classes.gallery}>
                     <Gallery data={items} title={title} pageSize={pageSize} />
                 </section>

--- a/packages/venia-concept/src/RootComponents/Product/Product.js
+++ b/packages/venia-concept/src/RootComponents/Product/Product.js
@@ -104,7 +104,10 @@ class Product extends Component {
                         ),
                         description: string,
                         short_description: string,
-                        canonical_url: string
+                        canonical_url: string,
+                        meta_title: string,
+                        meta_keyword: string,
+                        meta_description: string
                     })
                 ).isRequired
             }).isRequired

--- a/packages/venia-concept/src/components/App/app.js
+++ b/packages/venia-concept/src/components/App/app.js
@@ -6,6 +6,7 @@ import Mask from 'src/components/Mask';
 import MiniCart from 'src/components/MiniCart';
 import Navigation from 'src/components/Navigation';
 import OnlineIndicator from 'src/components/OnlineIndicator';
+import HtmlHead from 'src/components/HtmlHead';
 import renderRoutes from './renderRoutes';
 
 class App extends Component {
@@ -35,6 +36,7 @@ class App extends Component {
 
         return (
             <Fragment>
+                <HtmlHead />
                 <Main isMasked={overlay}>
                     {onlineIndicator}
                     {renderRoutes()}

--- a/packages/venia-concept/src/components/HtmlHead/head.js
+++ b/packages/venia-concept/src/components/HtmlHead/head.js
@@ -1,0 +1,84 @@
+import React, { Component } from 'react';
+import Helmet from 'react-helmet';
+
+import { Query } from 'react-apollo';
+import STORE_HEAD_CONFIG from '../../queries/getStoreHeadConfig.graphql';
+
+import { shape, string } from 'prop-types';
+
+class HtmlHead extends Component {
+    static propTypes = {
+        data: shape({
+            storeConfig: shape({
+                default_title: string,
+                title_prefix: string,
+                title_suffix: string,
+                default_keywords: string,
+                default_description: string
+            }).isRequired
+        })
+    };
+
+    render () {
+        let { title, meta_title, meta_keywords, meta_description } = this.props;
+
+        return (
+            <Query query={STORE_HEAD_CONFIG}>
+                {({ loading, error, data }) => {
+                    if (error) return <div>Data Fetch Error</div>;
+
+                    if (!data.storeConfig) {
+                        return '';
+                    }
+
+                    const titlePrefix = data.storeConfig.title_prefix;
+                    const titleSuffix = data.storeConfig.title_suffix;
+                    const defaultTitle = data.storeConfig.default_title;
+
+                    // Setting up the title
+                    if (!title) {
+                        title = defaultTitle;
+                    }
+
+                    if (titlePrefix) {
+                        title = titlePrefix + title;
+                    }
+
+                    if (titleSuffix) {
+                        title = title + titleSuffix;
+                    }
+
+                    // Setting up the meta title
+                    if (!meta_title) {
+                        meta_title = title;
+                    }
+
+                    // Setting up the meta keywords
+                    if (!meta_keywords) {
+                        meta_keywords = data.storeConfig.default_keywords;
+                    }
+
+                    // Setting up the meta description
+                    if (!meta_description) {
+                        meta_description = data.storeConfig.default_description;
+                    }
+
+                    return (
+                        <Helmet>
+                            <title>{title}</title>
+                            <meta name="title" content={meta_title} />
+                            {meta_keywords && (
+                                <meta name="keywords" content={meta_keywords} />
+                            )}
+                            {meta_description && (
+                                <meta name="description" content={meta_description} />
+                            )}
+                        </Helmet>
+                    );
+                }}
+            </Query>
+        );
+    }
+}
+
+export default HtmlHead;

--- a/packages/venia-concept/src/components/HtmlHead/index.js
+++ b/packages/venia-concept/src/components/HtmlHead/index.js
@@ -1,0 +1,1 @@
+export { default } from './head';

--- a/packages/venia-concept/src/components/ProductFullDetail/ProductFullDetail.js
+++ b/packages/venia-concept/src/components/ProductFullDetail/ProductFullDetail.js
@@ -9,6 +9,7 @@ import { loadingIndicator } from 'src/components/LoadingIndicator';
 import Carousel from 'src/components/ProductImageCarousel';
 import Quantity from 'src/components/ProductQuantity';
 import RichText from 'src/components/RichText';
+import HtmlHead from 'src/components/HtmlHead';
 import defaultClasses from './productFullDetail.css';
 
 const Options = React.lazy(() => import('../ProductOptions'));
@@ -162,6 +163,12 @@ class ProductFullDetail extends Component {
 
         return (
             <Form className={classes.root}>
+                <HtmlHead
+                    title={product.name}
+                    meta_title={product.meta_title}
+                    meta_keywords={product.meta_keyword}
+                    meta_description={product.meta_description}
+                />
                 <section className={classes.title}>
                     <h1 className={classes.productName}>
                         <span>{product.name}</span>

--- a/packages/venia-concept/src/queries/getStoreHeadConfig.graphql
+++ b/packages/venia-concept/src/queries/getStoreHeadConfig.graphql
@@ -1,0 +1,9 @@
+query getStoreHeadConfig{
+    storeConfig {
+        default_title
+        title_prefix
+        title_suffix
+        default_description
+        default_keywords
+    }
+}

--- a/packages/venia-concept/templates/generic-shell.mst
+++ b/packages/venia-concept/templates/generic-shell.mst
@@ -1,6 +1,5 @@
 {{> templates/doctype-and-head-start}}
 {{> templates/js-unavailable}}
-    <title>Venia</title>
   </head>
   <body>
     <div id="root">{{#urlResolver}}

--- a/packages/venia-concept/templates/index.mst
+++ b/packages/venia-concept/templates/index.mst
@@ -1,5 +1,4 @@
 {{> templates/doctype-and-head-start}}
-    <title>Venia</title>
   </head>
   <body>
     <div id="root"></div>

--- a/packages/venia-concept/templates/product-shell.mst
+++ b/packages/venia-concept/templates/product-shell.mst
@@ -1,16 +1,10 @@
 {{> templates/doctype-and-head-start}}
 {{> templates/js-unavailable}}
-    <title>{{model.name}} - {{site.name}}</title>
-    {{#model}}
-    <meta name="title" content="{{name}}">
-    <meta name="keywords" content="{{meta_keyword}}">
-    <meta name="description" content="{{#meta_description}}{{.}}{{/meta_description}}{{^meta_description}}{{description}}{{/meta_description}}">
   </head>
   <body>
     <div id="root">
         Loading {{name}}...
     </div>
-    {{/model}}
 {{> templates/preloads}}
 {{> templates/scripts}}
   </body>


### PR DESCRIPTION
<!-- (REQUIRED) What is the nature of this PR? -->

## This PR is a:

- [ ] New feature
- [ ] Enhancement/Optimization
- [ ] Refactor
- [X] Bugfix
- [ ] Test for existing code
- [ ] Documentation

<!-- (REQUIRED) What does this PR change? -->

## Summary

When this pull request is merged, it will:
1. Solve issue magento-research/pwa-studio#422
2. Adds page default title from System Configuration
3. Appends prefix and suffix (from System Configuration) to the page title if necessary
4. Adds category title, meta title, meta keywords and meta description to the current App state
5. Adds product title, meta title, meta keywords and meta description to the current App state
6. Introduces the `react-helmet` package to `venia-concept`

<!-- (OPTIONAL) What other information can you provide about this PR? -->

## Additional information
⚠️ This PR is dependent on one opened PR magento/graphql-ce#318. 
The thing is that that PR solves GraphQl issue for getting information about store design configuration, like `default title`, `title prefix`, `title suffix`, and so on, which are used to solve mentioned issue above.

----
Would be nice to have someone "instruct" me on what's wrong in this PR, how we can improve the current approach and give some advices for future PR.

P.S. this is my 1st PR and commitment to PWA
