### PR TITLE
fix(devcert): Monkeypatch devcert bug. Closes #679

### DIFF
--- a/packages/pwa-buildpack/src/Utilities/configureHost.js
+++ b/packages/pwa-buildpack/src/Utilities/configureHost.js
@@ -7,6 +7,26 @@ const chalk = require('chalk');
 const execa = require('execa');
 const { username } = os.userInfo();
 
+/**
+ * Monkeypatch devcert to fix
+ * https://github.com/magento-research/pwa-studio/issues/679 which is blocked by
+ * https://github.com/davewasmer/devcert/pull/30.
+ * TODO: Remove this when a release of devcert without this bug is available
+ */
+const devCertUtils = require('devcert/dist/utils');
+const MacOSPlatform = require('devcert/dist/platforms/darwin');
+const proto = (MacOSPlatform.default || MacOSPlatform).prototype;
+proto.isNSSInstalled = function() {
+    try {
+        return devCertUtils
+            .run('brew list -1')
+            .toString()
+            .includes('\nnss\n');
+    } catch (e) {
+        return false;
+    }
+};
+
 const DEFAULT_NAME = 'my-pwa';
 const DEV_DOMAIN = 'local.pwadev';
 


### PR DESCRIPTION
## Description

Monkeypatch to fix a bug in `devcert` which causes #679, using JS class mutability.

The bug described in #679 occurs when all of the following conditions are true:
- Developer is on OSX
- Developer has never run PWA Studio or `devcert` before
- Firefox is installed
- [Homebrew is installed](https://brew.sh/)
- `openssl` is installed through Homebrew, but Firefox certificate store `nss` is not _(This causes a false positive because the faulty devcert method looks for the string `nss`)_

The fix is to overwrite the `isNSSInstalled` method on devcert's MacOS class with a more accurate check.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here with the following wording: Closes #<issue> -->
Closes #679.
Should be removed when devcert merges and releases https://github.com/davewasmer/devcert/pull/30.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
If the above conditions are true (which is actually quite common for OSX devs), the developer has to run PWAStudio twice to get past this bug, which is unfriendly and nonintuitive.

## How Has This Been Tested?
I reproduced the above conditions by doing the following:
1. Ensured Firefox and Homebrew were installed
2. Ensured Homebrew had OpenSSL installed and NSS not installed, to reproduce false positive (`brew install ssl && brew remove nss`)
3. Removed devcert's stored configuration so devcert would attempt reinstall (`rm -rf ~/Library/Application\ Support/devcert`
4. Ran `yarn build && yarn watch:venia` to reproduce

Before the monkeypatch, the last step would fail with this error:

```sh
/bin/sh: /usr/local/Cellar/nss/3.42/bin/certutil: No such file or directory
Error: [pwa-buildpack:Utilities:configureHost.js] Could not setup development domain:
Error: Command failed: /usr/local/Cellar/nss/3.42/bin/certutil -A -d "sql:/Users/jzetlen/Library/Application Support/Firefox/Profiles/mqjjctkh.default" -t 'C,,' -i /var/folders/ng/0_3_8yn95y7fspt30kj97k0r0000gn/T/tmp-56987vjU0NHgW5c1A.tmp -n devcert
/bin/sh: /usr/local/Cellar/nss/3.42/bin/certutil: No such file or directory

    at checkExecSyncError (child_process.js:616:11)
    at Object.execSync (child_process.js:653:13)
    at Object.run (/Users/jzetlen/gits/pwa/pwa-studio/node_modules/devcert/dist/utils.js:24:28)
    at glob_1.sync.forEach (/Users/jzetlen/gits/pwa/pwa-studio/node_modules/devcert/dist/platforms/shared.js:32:25)
    at Array.forEach (<anonymous>)
    at Object.<anonymous> (/Users/jzetlen/gits/pwa/pwa-studio/node_modules/devcert/dist/platforms/shared.js:24:33)
    at Generator.next (<anonymous>)
    at /Users/jzetlen/gits/pwa/pwa-studio/node_modules/tslib/tslib.js:107:75
    at new Promise (<anonymous>)
    at Object.__awaiter (/Users/jzetlen/gits/pwa/pwa-studio/node_modules/tslib/tslib.js:103:16)
    at Object.addCertificateToNSSCertDB (/Users/jzetlen/gits/pwa/pwa-studio/node_modules/devcert/dist/platforms/shared.js:22:20)
    at MacOSPlatform.<anonymous> (/Users/jzetlen/gits/pwa/pwa-studio/node_modules/devcert/dist/platforms/darwin.js:51:32)
    at Generator.next (<anonymous>)
    at fulfilled (/Users/jzetlen/gits/pwa/pwa-studio/node_modules/tslib/tslib.js:104:62)
    at process._tickCallback (internal/process/next_tick.js:68:7)
    at configureHost (/Users/jzetlen/gits/pwa/pwa-studio/packages/pwa-buildpack/dist/Utilities/configureHost.js:144:11)
    at process._tickCallback (internal/process/next_tick.js:68:7)
/bin/sh: line 0: cd: OLDPWD not set
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

After the monkeypatch, all steps would succeed.

## Screenshots (if appropriate):

## Proposed Labels for Change Type/Package
<!--- What types of changes does your code introduce? Let us know if this is a -->
<!--- BUG, FEATURE, DOCUMENTATION, or TEST change. -->
Fixes a BUG in `pwa-buildpack`.

<!--- What packages are modified by this code? Let us know if this applies to -->
<!--- peregrine, pwa-buildpack, upward-js, upward-spec, venia-concept or pwa-devdocs -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have linked an issue to this PR.
- [x] I have indicated the change type and relevant package(s).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] All CI checks are green (linting, build/deploy, etc).
- [ ] At least one core contributor has approved this PR.
