### PR TITLE
fix(cart): addItemToCart should wait until item added to open cart

### DIFF
--- a/packages/venia-concept/src/actions/cart/__tests__/asyncActions.spec.js
+++ b/packages/venia-concept/src/actions/cart/__tests__/asyncActions.spec.js
@@ -354,6 +354,7 @@ test('addItemToCart opens drawer and gets cart details on success', async () => 
         .mockImplementationOnce(fakeDispatch)
         .mockImplementationOnce(fakeDispatch)
         .mockImplementationOnce(fakeDispatch)
+        .mockImplementationOnce(fakeDispatch)
         .mockImplementationOnce(fakeDispatch);
 
     request.mockResolvedValueOnce(cartItem).mockResolvedValueOnce(cartItem);

--- a/packages/venia-concept/src/actions/cart/asyncActions.js
+++ b/packages/venia-concept/src/actions/cart/asyncActions.js
@@ -126,10 +126,8 @@ export const addItemToCart = (payload = {}) => {
             }
         }
 
-        await Promise.all([
-            dispatch(toggleDrawer('cart')),
-            dispatch(getCartDetails({ forceRefresh: true }))
-        ]);
+        await dispatch(getCartDetails({ forceRefresh: true }));
+        await dispatch(toggleDrawer('cart'));
     };
 };
 


### PR DESCRIPTION
<!--
Thank you for your contribution!

Before submitting this pull request, please make sure you have read our Contribution Guidelines and your PR meets our contribution standards:
https://github.com/magento-research/pwa-studio/blob/master/.github/CONTRIBUTION.md

Please fill out as much information as you can about your PR to help speed up the review process.
If your PR addresses an existing GitHub Issue, please refer to it in the title or Additional Information section to make the connection.

We may ask you for changes in your PR in order to meet the standards set in our Contribution Guidelines. PRs that do not comply with our guidelines may be closed at the maintainers' discretion.

Feel free to remove this section before creating this PR.
-->

## Description
<!--- Provide a general summary of your changes in the Title above -->
<!--- Describe your changes in detail here: -->
The addItemToCart action opens the cart before adding the item. When the cart is empty, this causes a confusing interaction.

![venia-cart-bad](https://user-images.githubusercontent.com/1643758/52233584-504c3600-2874-11e9-9031-da4109d94b70.gif)

This PR changes the addItemToCart action so the API call to add the cart and retrieve the updated cart completes before the cart opens.

## Related Issue


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Tested locally.

## Screenshots (if appropriate):

![venia-cart-good](https://user-images.githubusercontent.com/1643758/52233641-7376e580-2874-11e9-82bb-ec4d4233ce13.gif)

## Proposed Labels for Change Type/Package
<!--- What types of changes does your code introduce? Let us know if this is a -->
<!--- BUG, FEATURE, DOCUMENTATION, or TEST change. -->
BUG venia-concept

<!--- What packages are modified by this code? Let us know if this applies to -->
<!--- peregrine, pwa-buildpack, upward-js, upward-spec, venia-concept or pwa-devdocs -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have linked an issue to this PR.
- [x] I have indicated the change type and relevant package(s).
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] All CI checks are green (linting, build/deploy, etc).
- [ ] At least one core contributor has approved this PR.
