### PR TITLE
829 - remove an action from First/Last button of the pagination  when…

### DIFF
--- a/packages/venia-concept/src/components/Pagination/pagination.js
+++ b/packages/venia-concept/src/components/Pagination/pagination.js
@@ -102,7 +102,10 @@ class Pagination extends Component {
     }
 
     setPage = pageNumber => {
-        this.props.pageControl.setPage(pageNumber);
+        const currentPage = this.props.pageControl.currentPage;
+        if (currentPage !== pageNumber) {
+            this.props.pageControl.setPage(pageNumber);
+        }
     };
 
     slideNavLeft = () => {


### PR DESCRIPTION
## Remove action from the First/Last button of the pagination when a user already on the First/Last page respectively
In this PR removes an action from the pagination Last/First buttons when a user is already in the Last/Fist page. This was done to avoid scrolling the page to the top.

## Related Issue
Closes #829 .

## Motivation and Context
Improve the user experience in the category page.

## How Has This Been Tested?
Tested using the https://release-dev-rxvv2iq-zddsyhrdimyra.us-4.magentosite.cloud/ instance

## Screenshots (if appropriate):
Actual:
![829-actual](https://user-images.githubusercontent.com/10513114/52341227-b5419080-2a1a-11e9-894f-9c79890ab5f7.gif)

With a fix:
![829-fix](https://user-images.githubusercontent.com/10513114/52341242-bb377180-2a1a-11e9-9746-ccdfe4ba5de5.gif)


## Proposed Labels for Change Type/Package
BUG

venia-concept

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] I have linked an issue to this PR.
- [x] I have indicated the change type and relevant package(s).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All CI checks are green (linting, build/deploy, etc).
- [ ] At least one core contributor has approved this PR.

