### PR TITLE
remove prettier from prepush hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-push": "yarn run prettier && yarn run prettier:validate && yarn run lint"
+      "pre-push": "yarn run prettier:validate && yarn run lint"
     }
   },
   "bundlesize": [


### PR DESCRIPTION
## Description
It doesn't make sense to run `prettier` on prepush, we would need to run it on precommit for it to be committed before pushing it up. So just removing this for now. Folks will have to run the prettier command if the `prettier:validate` script fails.

Closes #860 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have linked an issue to this PR.
- [ ] I have indicated the change type and relevant package(s).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All CI checks are green (linting, build/deploy, etc).
- [ ] At least one core contributor has approved this PR.
