### PR TITLE
fix(dev): Hide spam warnings from babel-plugin-module-resolver

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,5 +1,5 @@
 const browsers = require('./browserslist');
-const chalk = require('chalk');
+const { resolvePath } = require('babel-plugin-module-resolver');
 
 const plugins = [
     ['@babel/plugin-proposal-class-properties'],
@@ -16,17 +16,7 @@ const targets = {
     test: 'node 10'
 };
 
-let warned = false;
-
 const config = api => {
-    if (process.env.WARN_RESOLVE) {
-        warned = true;
-        console.warn(
-            chalk.bold.yellowBright(
-                'You may see some warnings that @magento/venia-drivers could not be resolved. This is normal and not an error; Venia exports a virtual import path and babel-plugin-module-resolver is hardcoded to warn about it.'
-            )
-        );
-    }
     const envConfigs = {
         /**
          * Watch mode and build:esm partial transpilation mode.
@@ -65,7 +55,11 @@ const config = api => {
                          */
                         alias: {
                             '^src/drivers$': '@magento/venia-drivers'
-                        }
+                        },
+                        /**
+                         * Suppress console warning about missing dependencies.
+                         */
+                        loglevel: 'silent'
                     }
                 ]
             ],

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   "devDependencies": {
     "@magento/eslint-config": "~1.3.0",
     "babel-eslint": "~10.0.1",
-    "babel-plugin-module-resolver": "~3.1.3",
+    "babel-plugin-module-resolver": "~3.2.0",
     "bundlesize": "~0.17.1",
     "chalk": "~2.4.2",
     "chokidar": "~2.0.4",

--- a/packages/venia-concept/package.json
+++ b/packages/venia-concept/package.json
@@ -16,7 +16,7 @@
     "build": "yarn run clean && yarn run build:esm && yarn run validate-queries && yarn run build:prod",
     "build:analyze": "yarn run clean && mkdir dist && yarn run validate-queries && yarn run build:stats",
     "build:dev": "echo 'Skipping venia-concept build...'",
-    "build:esm": "BABEL_ENV=development WARN_RESOLVE=1 babel src --out-dir esm --root-mode 'upward' --source-maps --copy-files",
+    "build:esm": "BABEL_ENV=development babel src --out-dir esm --root-mode 'upward' --source-maps --copy-files",
     "build:prod": "webpack -p --color --progress --profile --env.mode production",
     "clean": "rimraf dist esm",
     "prepublishOnly": "yarn run build",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3538,10 +3538,10 @@ babel-plugin-minify-type-constructors@^0.4.3:
   dependencies:
     babel-helper-is-void-0 "^0.4.3"
 
-babel-plugin-module-resolver@~3.1.3:
-  version "3.1.3"
-  resolved "https://registry.yarnpkg.com/babel-plugin-module-resolver/-/babel-plugin-module-resolver-3.1.3.tgz#5a1c148bf528d20907ed508b70ae3c4762e78c8d"
-  integrity sha512-QRfA8b2H7l9uSElLwS0rHoPhjPhgpncKUvrn42tJpdCoJ3IS6J+m4mp5FtnRoXHry3ZYJ2SMLLG/REikQA6tjg==
+babel-plugin-module-resolver@~3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-module-resolver/-/babel-plugin-module-resolver-3.2.0.tgz#ddfa5e301e3b9aa12d852a9979f18b37881ff5a7"
+  integrity sha512-tjR0GvSndzPew/Iayf4uICWZqjBwnlMWjSx6brryfQ81F9rxBVqwDJtFCV8oOs0+vJeefK9TmdZtkIFdFe1UnA==
   dependencies:
     find-babel-config "^1.1.0"
     glob "^7.1.2"


### PR DESCRIPTION
## Description
Fixes #880. We use an interceptor API for the plugin's `resolvePath` function, which simulates the environment variable while the plugin runs. This works and suppresses the warning, so we removed the explanator `console.warn()` call as well.


## Related Issue
<!--- This project only accepts pull requests related to open issues -->
Closes #880.

## Motivation and Context
Devex is a primary quality measure of this project, and useless worrisome console output is one of the worst things for devex.

## How Has This Been Tested?
Tested in all environments and Node versions.

## Screenshots (if appropriate):
Compare to screeshot in #880:

![image](https://user-images.githubusercontent.com/1643758/52536568-ecb58300-2d21-11e9-8756-95a0864b73aa.png)

## Proposed Labels for Change Type/Package
<!--- What types of changes does your code introduce? Let us know if this is a -->
<!--- BUG, FEATURE, DOCUMENTATION, or TEST change. -->
BUG
Improved devex

<!--- What packages are modified by this code? Let us know if this applies to -->
<!--- peregrine, pwa-buildpack, upward-js, upward-spec, venia-concept or pwa-devdocs -->
Affects venia-concept, even though changes are in root babel.config.js

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have linked an issue to this PR.
- [x] I have indicated the change type and relevant package(s).
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All CI checks are green (linting, build/deploy, etc).
- [ ] At least one core contributor has approved this PR.
