### PR TITLE
fix(test): unignore __stories__ from babel. Fixes #862

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -2,6 +2,7 @@
 coverage
 # Minified build assets
 dist
+storybook-dist
 # Babelified ES modules for NPM dependents
 esm
 # Devdocs is a separate project

--- a/babel.config.js
+++ b/babel.config.js
@@ -34,8 +34,8 @@ const config = api => {
          * package root, like 'src/classify'.
          */
         development: {
-            // Ignore __mocks__, __stories__, etc.
-            ignore: [/\/__\w+__\//],
+            // Ignore everything with underscores except stories
+            ignore: [/\/__(tests?|mocks|fixtures|helpers)__\//],
             plugins: [
                 ...plugins,
                 [

--- a/packages/peregrine/package.json
+++ b/packages/peregrine/package.json
@@ -35,7 +35,7 @@
     "@babel/plugin-transform-react-jsx": "~7.2.0",
     "@babel/plugin-transform-runtime": "~7.2.0",
     "@babel/runtime": "~7.2.0",
-    "@storybook/react": "~4.1.6",
+    "@storybook/react": "~4.1.11",
     "concurrently": "~4.1.0",
     "intl": "~1.2.5",
     "react": "~16.8.0",

--- a/packages/pwa-buildpack/.babelrc.js
+++ b/packages/pwa-buildpack/.babelrc.js
@@ -1,6 +1,6 @@
 const config = {
-    // Ignore __mocks__, __stories__, etc.
-    ignore: [/\/__\w+__\//],
+    // Ignore everything with underscores except stories
+    ignore: [/\/__(tests?|mocks|fixtures|helpers)__\//],
     plugins: [
         ['@babel/plugin-proposal-class-properties', { loose: false }],
         ['@babel/plugin-syntax-jsx'],

--- a/packages/venia-concept/package.json
+++ b/packages/venia-concept/package.json
@@ -72,7 +72,7 @@
     "@babel/preset-env": "~7.2.3",
     "@magento/pwa-buildpack": "^2.0.0-rc.19",
     "@magento/upward-js": "^2.0.0-rc.19",
-    "@storybook/react": "~4.1.6",
+    "@storybook/react": "~4.1.11",
     "babel-core": "~7.0.0-bridge.0",
     "babel-jest": "~23.6.0",
     "babel-loader": "~8.0.5",

--- a/packages/venia-concept/src/components/Header/__stories__/header.js
+++ b/packages/venia-concept/src/components/Header/__stories__/header.js
@@ -1,27 +1,31 @@
 import React from 'react';
-import { Provider } from 'react-redux';
-import { BrowserRouter as Router } from 'react-router-dom';
 import { storiesOf } from '@storybook/react';
-import { Header } from '../header';
+
+import Header from '../header';
 import defaultClasses from '../header.css';
 import 'src/index.css';
-
-import { store } from 'src/store';
+import { Adapter } from 'src/drivers';
+import store from 'src/store';
 
 const stories = storiesOf('Header', module);
+const apiBase = new URL('/graphql', location.origin).toString();
 
 stories.add('Search Bar Closed', () => (
-    <Provider store={store}>
-        <Router>
-            <Header classes={defaultClasses} searchOpen={false} />
-        </Router>
-    </Provider>
+    <Adapter
+        apiBase={apiBase}
+        apollo={{ link: Adapter.apolloLink(apiBase) }}
+        store={store}
+    >
+        <Header classes={defaultClasses} searchOpen={false} />
+    </Adapter>
 ));
 
 stories.add('Search Bar Open', () => (
-    <Provider store={store}>
-        <Router>
-            <Header classes={defaultClasses} searchOpen={true} />
-        </Router>
-    </Provider>
+    <Adapter
+        apiBase={apiBase}
+        apollo={{ link: Adapter.apolloLink(apiBase) }}
+        store={store}
+    >
+        <Header classes={defaultClasses} searchOpen={true} />
+    </Adapter>
 ));

--- a/packages/venia-concept/src/components/Header/__stories__/header.js
+++ b/packages/venia-concept/src/components/Header/__stories__/header.js
@@ -9,6 +9,7 @@ import store from 'src/store';
 
 const stories = storiesOf('Header', module);
 const apiBase = new URL('/graphql', location.origin).toString();
+const noop = () => {};
 
 stories.add('Search Bar Closed', () => (
     <Adapter
@@ -16,7 +17,11 @@ stories.add('Search Bar Closed', () => (
         apollo={{ link: Adapter.apolloLink(apiBase) }}
         store={store}
     >
-        <Header classes={defaultClasses} searchOpen={false} />
+        <Header
+            classes={defaultClasses}
+            searchOpen={false}
+            toggleSearch={noop}
+        />
     </Adapter>
 ));
 
@@ -26,6 +31,10 @@ stories.add('Search Bar Open', () => (
         apollo={{ link: Adapter.apolloLink(apiBase) }}
         store={store}
     >
-        <Header classes={defaultClasses} searchOpen={true} />
+        <Header
+            classes={defaultClasses}
+            searchOpen={true}
+            toggleSearch={noop}
+        />
     </Adapter>
 ));

--- a/packages/venia-concept/src/components/MiniCart/__stories__/Kebab.js
+++ b/packages/venia-concept/src/components/MiniCart/__stories__/Kebab.js
@@ -15,7 +15,7 @@ const styles = {
 
 stories.add('Kebab Closed', () => (
     <div style={styles}>
-        <Kebab />
+        <Kebab isOpen={false} />
     </div>
 ));
 

--- a/packages/venia-concept/src/components/MiniCart/__stories__/Kebab.js
+++ b/packages/venia-concept/src/components/MiniCart/__stories__/Kebab.js
@@ -22,9 +22,9 @@ stories.add('Kebab Closed', () => (
 stories.add('Kebab Open', () => (
     <div style={styles}>
         <Kebab isOpen={true}>
-            <Section icon="heart" text="Section 1" />
-            <Section icon="x" text="Section 2" />
-            <Section icon="chevron-up" text="Section 3" />
+            <Section icon="Heart" text="Section 1" />
+            <Section icon="Edit2" text="Section 2" />
+            <Section icon="Trash" text="Section 3" />
             <Section text="Non-icon Section" />
         </Kebab>
     </div>

--- a/packages/venia-concept/src/components/MiniCart/kebab.js
+++ b/packages/venia-concept/src/components/MiniCart/kebab.js
@@ -22,7 +22,7 @@ class Kebab extends Component {
         this.kebabButtonRef = createRef();
 
         this.state = {
-            isOpen: !!this.props.isOpen
+            isOpen: !!props.isOpen
         };
     }
 

--- a/packages/venia-concept/src/components/MiniCart/kebab.js
+++ b/packages/venia-concept/src/components/MiniCart/kebab.js
@@ -1,5 +1,5 @@
 import React, { Component, createRef } from 'react';
-
+import { bool, shape, string } from 'prop-types';
 import Icon from 'src/components/Icon';
 import classify from 'src/classify';
 import defaultClasses from './kebab.css';
@@ -7,14 +7,24 @@ import defaultClasses from './kebab.css';
 import MoreVerticalIcon from 'react-feather/dist/icons/more-vertical';
 
 class Kebab extends Component {
+    static propTypes = {
+        classes: shape({
+            dropdown: string,
+            dropdown_active: string,
+            kebab: string,
+            root: string
+        }),
+        isOpen: bool
+    };
+
     constructor(props) {
         super(props);
         this.kebabButtonRef = createRef();
-    }
 
-    state = {
-        isOpen: this.props.isOpen
-    };
+        this.state = {
+            isOpen: !!this.props.isOpen
+        };
+    }
 
     componentDidMount() {
         document.addEventListener('click', this.handleDocumentClick);
@@ -33,9 +43,17 @@ class Kebab extends Component {
     }
 
     render() {
-        const { classes, children, ...restProps } = this.props;
-        const { isOpen } = this.state;
-        const toggleClass = isOpen ? classes.dropdown_active : classes.dropdown;
+        const {
+            classes,
+            children,
+            //eslint-disable-next-line
+            isOpen,
+            ...restProps
+        } = this.props;
+
+        const toggleClass = this.state.isOpen
+            ? classes.dropdown_active
+            : classes.dropdown;
 
         return (
             <div {...restProps} className={classes.root}>

--- a/packages/venia-concept/src/components/MiniCart/kebab.js
+++ b/packages/venia-concept/src/components/MiniCart/kebab.js
@@ -19,6 +19,9 @@ class Kebab extends Component {
     componentDidMount() {
         document.addEventListener('click', this.handleDocumentClick);
         document.addEventListener('touchend', this.handleDocumentClick);
+        if (this.props.isOpen) {
+            this.setState({ isOpen: true });
+        }
     }
 
     handleDocumentClick = event => {

--- a/packages/venia-concept/src/components/MiniCart/kebab.js
+++ b/packages/venia-concept/src/components/MiniCart/kebab.js
@@ -13,15 +13,12 @@ class Kebab extends Component {
     }
 
     state = {
-        isOpen: false
+        isOpen: this.props.isOpen
     };
 
     componentDidMount() {
         document.addEventListener('click', this.handleDocumentClick);
         document.addEventListener('touchend', this.handleDocumentClick);
-        if (this.props.isOpen) {
-            this.setState({ isOpen: true });
-        }
     }
 
     handleDocumentClick = event => {

--- a/packages/venia-concept/src/components/MiniCart/product.js
+++ b/packages/venia-concept/src/components/MiniCart/product.js
@@ -127,7 +127,7 @@ class Product extends Component {
                         onClick={this.favoriteItem}
                         icon="Heart"
                         iconAttributes={
-                            this.state.isFavorite ? favoritesFill : ''
+                            this.state.isFavorite ? favoritesFill : {}
                         }
                     />
                     <Section

--- a/packages/venia-concept/src/components/MiniCart/section.js
+++ b/packages/venia-concept/src/components/MiniCart/section.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-
+import { func, object, oneOf, shape, string } from 'prop-types';
 import Icon from 'src/components/Icon';
 import HeartIcon from 'react-feather/dist/icons/heart';
 import Edit2Icon from 'react-feather/dist/icons/edit-2';
@@ -14,6 +14,17 @@ const SectionIcons = {
 };
 
 class Section extends Component {
+    static propTypes = {
+        classes: shape({
+            menuItem: string,
+            text: string
+        }),
+        icon: oneOf(['Heart', 'Edit2', 'Trash']),
+        iconAttributes: object,
+        onClick: func,
+        text: string
+    };
+
     get icon() {
         const { icon } = this.props;
         const defaultAttributes = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1816,39 +1816,39 @@
   resolved "https://registry.yarnpkg.com/@protobufjs/utf8/-/utf8-1.1.0.tgz#a777360b5b39a1a2e5106f8e858f2fd2d060c570"
   integrity sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA=
 
-"@storybook/addons@4.1.6":
-  version "4.1.6"
-  resolved "https://registry.yarnpkg.com/@storybook/addons/-/addons-4.1.6.tgz#458c4c6baf8b2acaffb9ced705a8db224bd874b6"
-  integrity sha512-5dG0adChzNRbRLS/YD/5mEoWLTk3uaJpzbRSJVKe6HQKBPDXmuEMYYPiHI83o15YBJjGHx68+PkHBI08oRsuhQ==
+"@storybook/addons@4.1.11":
+  version "4.1.11"
+  resolved "https://registry.yarnpkg.com/@storybook/addons/-/addons-4.1.11.tgz#a0d537bd10d123ecee6cb1f5f149b148ce250e57"
+  integrity sha512-n9oDs7GgJbiN5NYPkR3B3e5W0Tr6bIZvFfcJzgyP4dn50AUvS1IE1CEthezfn1L/nc2suw/8Oe30bOXOyTl/SQ==
   dependencies:
-    "@storybook/channels" "4.1.6"
-    "@storybook/components" "4.1.6"
+    "@storybook/channels" "4.1.11"
+    "@storybook/components" "4.1.11"
     global "^4.3.2"
     util-deprecate "^1.0.2"
 
-"@storybook/channel-postmessage@4.1.6":
-  version "4.1.6"
-  resolved "https://registry.yarnpkg.com/@storybook/channel-postmessage/-/channel-postmessage-4.1.6.tgz#ff7af1c0ee1ab72ee8f10ec2e29cd413c39fc14d"
-  integrity sha512-CUFcnzZE5y24AUZqArt9/95wLdk0phsrOzDU8Q/WNWpzYCzTaaNzd82DDG4AWWHd7awtbgGGueKDCoAXU99t5A==
+"@storybook/channel-postmessage@4.1.11":
+  version "4.1.11"
+  resolved "https://registry.yarnpkg.com/@storybook/channel-postmessage/-/channel-postmessage-4.1.11.tgz#3320a5f3e05652466eff1c53843205c262a92dfb"
+  integrity sha512-/9p4I5CZWVl6mszY5AR5XPRdQ88LUaAt4iyhdxMIaqNRiVo3Rq4ptMXiw35eCr+sLQuG2KO2SiPIwaA4/FgQuw==
   dependencies:
-    "@storybook/channels" "4.1.6"
+    "@storybook/channels" "4.1.11"
     global "^4.3.2"
     json-stringify-safe "^5.0.1"
 
-"@storybook/channels@4.1.6":
-  version "4.1.6"
-  resolved "https://registry.yarnpkg.com/@storybook/channels/-/channels-4.1.6.tgz#52b56f5c94f58442aba2d9c5919bb00ff33475c5"
-  integrity sha512-8MqGYypdaPmZR7eORXdxtJijGOz5UMHXoMskVtodvKi26tmltFKX+okXFNh/teKe3+8s0QWkpzM95VI+Z+0qFA==
+"@storybook/channels@4.1.11":
+  version "4.1.11"
+  resolved "https://registry.yarnpkg.com/@storybook/channels/-/channels-4.1.11.tgz#d161497fa3cd848cc9d518aa1c37052857e22e3c"
+  integrity sha512-zYusY8cno4keMozn2lDpBgyNSOueFh+hrPETioSB5Z8Kd3F5OjM7681vJC8QA67yOBEie2hHk0CVxRpuxziMwA==
 
-"@storybook/client-logger@4.1.6":
-  version "4.1.6"
-  resolved "https://registry.yarnpkg.com/@storybook/client-logger/-/client-logger-4.1.6.tgz#3409c20467abe4f98751db9a8d6769c21d0c80e5"
-  integrity sha512-P65Pw3m2FRW7QDIU51zj3ANzo7twL7/9nQKoyMJKy/1rgqk1RMa/boHERPRhfATzqYPf5hh2G0PBTMKBEG4A8w==
+"@storybook/client-logger@4.1.11":
+  version "4.1.11"
+  resolved "https://registry.yarnpkg.com/@storybook/client-logger/-/client-logger-4.1.11.tgz#2b1e34e892045199592fdb01656e5dcdcd1999d7"
+  integrity sha512-Xxy6sY7Zd405o28wUAhlpqY2FbSZsTrsN3g/uo4Mqo4XD2f0Z4wIv1GOuM5DI2KlHpHGI+36YPO2VFx5Bq+yiQ==
 
-"@storybook/components@4.1.6":
-  version "4.1.6"
-  resolved "https://registry.yarnpkg.com/@storybook/components/-/components-4.1.6.tgz#f4430c77fc3eceddcd912a6c5e461554539c4f4d"
-  integrity sha512-kWIUiexzFurNwW8NaJEhlFWD1kohnvNlOxgph7oSoXo/yCBodkEYpIuNbznQnNSH2xIjqh1dvbniJNSJZyEbTQ==
+"@storybook/components@4.1.11":
+  version "4.1.11"
+  resolved "https://registry.yarnpkg.com/@storybook/components/-/components-4.1.11.tgz#25458a4a4f2edd836b1e4b944cfcfcb4a3567036"
+  integrity sha512-KJA8Nr8MbXiibDLcndx1GRVmVDyBBL2Tbb1kfQfr58vDwz6qhYxempejY6W+voaEqohnFxrOtnnbqlCyf8peUQ==
   dependencies:
     "@emotion/core" "^0.13.1"
     "@emotion/provider" "^0.11.2"
@@ -1861,27 +1861,27 @@
     react-textarea-autosize "^7.0.4"
     render-fragment "^0.1.1"
 
-"@storybook/core-events@4.1.6":
-  version "4.1.6"
-  resolved "https://registry.yarnpkg.com/@storybook/core-events/-/core-events-4.1.6.tgz#6c147b171a04cee3ed66990ebdf45be45dc658ba"
-  integrity sha512-07ki5+VuruWQv7B1ZBlsNYEVSC3dQwIZKjEFL4aKFO57ruaNijkZTF1QHkSGJapyBPa7+LLM2fXqnBkputoEZw==
+"@storybook/core-events@4.1.11":
+  version "4.1.11"
+  resolved "https://registry.yarnpkg.com/@storybook/core-events/-/core-events-4.1.11.tgz#78cfb2b4014ca27909421cdebfa9c96533929a5a"
+  integrity sha512-rVb76xFLJkTFcBHL1oTdJW8O2N7q+Cc6Mo7v9u3TnM4WuRk08/GyzzO7sRvEg3Mvo59AOLu1uqYovRMo4tZEnQ==
 
-"@storybook/core@4.1.6":
-  version "4.1.6"
-  resolved "https://registry.yarnpkg.com/@storybook/core/-/core-4.1.6.tgz#818124a8d47c9432637e000e509b01d051b9603e"
-  integrity sha512-0T4mDt3Wzyg8UIrF0kPvP5kA+S+fGhaZI/vWGUPvmxsYuVQHGhvna1ZiayIW8R9TdHx1g+uSYkUxb8wVVUmwQA==
+"@storybook/core@4.1.11":
+  version "4.1.11"
+  resolved "https://registry.yarnpkg.com/@storybook/core/-/core-4.1.11.tgz#f91cf77d4750edeb92717f6b2a2a4258b0a06c64"
+  integrity sha512-iUrtFCav7xJicCLhp4zdqbhaOXRWXrx4wMPSs0keBD2G7NQtSg/TQMUdx2VYFBl5thIFT1jt5dAm66y0Q2OCTQ==
   dependencies:
     "@babel/plugin-proposal-class-properties" "^7.2.0"
     "@babel/preset-env" "^7.2.0"
     "@emotion/core" "^0.13.1"
     "@emotion/provider" "^0.11.2"
     "@emotion/styled" "^0.10.6"
-    "@storybook/addons" "4.1.6"
-    "@storybook/channel-postmessage" "4.1.6"
-    "@storybook/client-logger" "4.1.6"
-    "@storybook/core-events" "4.1.6"
-    "@storybook/node-logger" "4.1.6"
-    "@storybook/ui" "4.1.6"
+    "@storybook/addons" "4.1.11"
+    "@storybook/channel-postmessage" "4.1.11"
+    "@storybook/client-logger" "4.1.11"
+    "@storybook/core-events" "4.1.11"
+    "@storybook/node-logger" "4.1.11"
+    "@storybook/ui" "4.1.11"
     airbnb-js-shims "^1 || ^2"
     autoprefixer "^9.3.1"
     babel-plugin-macros "^2.4.2"
@@ -1945,10 +1945,10 @@
     "@storybook/react-simple-di" "^1.2.1"
     babel-runtime "6.x.x"
 
-"@storybook/node-logger@4.1.6":
-  version "4.1.6"
-  resolved "https://registry.yarnpkg.com/@storybook/node-logger/-/node-logger-4.1.6.tgz#005b6f388a1c3a498c50a9b9d8cc3c4351827d6a"
-  integrity sha512-3mLcNp0eTjwQKHJ0vWpZLlayPOUaZJR/Umc6kWzdMn1K398/k7FU0fBK4FJ7VmnI0z1sYTlqaTqjqN0U3XaxjA==
+"@storybook/node-logger@4.1.11":
+  version "4.1.11"
+  resolved "https://registry.yarnpkg.com/@storybook/node-logger/-/node-logger-4.1.11.tgz#8ea9779eb6260a02bf06c02eafbff5925b883f9f"
+  integrity sha512-rCXk1PUcakkV72oyTR+nOVDUGnkk1On8/sm9u3NtBEUuwsCtm4p+jh42Pp4jsTtWpG36AVABDtiN65VgCfS+9w==
   dependencies:
     chalk "^2.4.1"
     core-js "^2.5.7"
@@ -1992,17 +1992,17 @@
   dependencies:
     babel-runtime "^6.5.0"
 
-"@storybook/react@~4.1.6":
-  version "4.1.6"
-  resolved "https://registry.yarnpkg.com/@storybook/react/-/react-4.1.6.tgz#e597ea2e4d6ce09b5843c287db9baaa97076731c"
-  integrity sha512-JavzdoIrLQprLlt/0Bm0QMKMOzqweL7gjXKSl8W5p38hhDpyxRt989t0yfZnwF6K0iGWeU88mAb9OoRkn7o8tA==
+"@storybook/react@~4.1.11":
+  version "4.1.11"
+  resolved "https://registry.yarnpkg.com/@storybook/react/-/react-4.1.11.tgz#fb3cda82fd3334a6653325ec281a2da284ac6895"
+  integrity sha512-NPNcfOlWmFBevza/+GXIK23h46HqdWKFmId19E0PtoWGoR5xOR56rnwagr2+yHngUb4AATUCzhzTwxfWGxSvBg==
   dependencies:
     "@babel/plugin-transform-react-constant-elements" "^7.2.0"
     "@babel/preset-flow" "^7.0.0"
     "@babel/preset-react" "^7.0.0"
     "@emotion/styled" "^0.10.6"
-    "@storybook/core" "4.1.6"
-    "@storybook/node-logger" "4.1.6"
+    "@storybook/core" "4.1.11"
+    "@storybook/node-logger" "4.1.11"
     "@svgr/webpack" "^4.0.3"
     babel-plugin-named-asset-import "^0.2.3"
     babel-plugin-react-docgen "^2.0.0"
@@ -2018,16 +2018,16 @@
     semver "^5.6.0"
     webpack "^4.23.1"
 
-"@storybook/ui@4.1.6":
-  version "4.1.6"
-  resolved "https://registry.yarnpkg.com/@storybook/ui/-/ui-4.1.6.tgz#f8516dc03c2b5e4c57352c5fc6b26eaf9fd25488"
-  integrity sha512-MXod0JMu/P2sTYlN6DM6yuwvizUKjwFn4lOf+F9hNe4lxZEXw74KogCv0CN32VUrWUP++ZY9DybQr4SMRFVVww==
+"@storybook/ui@4.1.11":
+  version "4.1.11"
+  resolved "https://registry.yarnpkg.com/@storybook/ui/-/ui-4.1.11.tgz#0c6fc34a8096028ef236a5196e7b91831702f2fb"
+  integrity sha512-bgIagh2Z4flGA7jv4JN++ThLwGq8CI8Wq+1/vhCiTxjTE3H1j9VNPdJfhNgxrQypcLRVHl5AKhf0mlSMyz0S1A==
   dependencies:
     "@emotion/core" "^0.13.1"
     "@emotion/provider" "^0.11.2"
     "@emotion/styled" "^0.10.6"
-    "@storybook/components" "4.1.6"
-    "@storybook/core-events" "4.1.6"
+    "@storybook/components" "4.1.11"
+    "@storybook/core-events" "4.1.11"
     "@storybook/mantra-core" "^1.7.2"
     "@storybook/podda" "^1.2.3"
     "@storybook/react-komposer" "^2.0.5"


### PR DESCRIPTION
## Description
The root babel.config.js had a generic ignore statement that wouldn't compile or copy anything from a folder with double underscore delimiters, like `__tests__`. But Storybook wants Babel to compile `__stories__`, so this PR adjusts the ignore statement to allow `__stories__` to be compiled.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here with the specific wording: "Closes #<issue>" -->
<!--- Using the above wording causes Github to automatically close the issue on merge. -->
Closes #862.

## Motivation and Context
Storybook was broken and it needs to work.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested locally.

## Proposed Labels for Change Type/Package
<!--- What types of changes does your code introduce? Let us know if this is a -->
<!--- BUG, FEATURE, DOCUMENTATION, or TEST change. -->
BUG, TEST in peregrine and venia-concept

<!--- What packages are modified by this code? Let us know if this applies to -->
<!--- peregrine, pwa-buildpack, upward-js, upward-spec, venia-concept or pwa-devdocs -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have linked an issue to this PR.
- [x] I have indicated the change type and relevant package(s).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] All CI checks are green (linting, build/deploy, etc).
- [ ] At least one core contributor has approved this PR.
