### PR TITLE
Fix Storybook compilation by removing Venia plugins

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,6 +31,10 @@ common_settings:
     name: Full build
     command: 'cp packages/venia-concept/.env.dist packages/venia-concept/.env && yarn run clean:dist && yarn run build'
 
+  storybook_build: &storybook_build
+    name: Storybook compilation
+    command: yarn workspace @magento/venia-concept run storybook-build
+
   test_result_path: &test_result_path
     path: "test-results"
 
@@ -50,6 +54,7 @@ jobs:
           name: Coveralls coverage analysis
           command: yarn run coveralls
       - run: *full_build
+      - run: *storybook_build
       - store_test_results: *test_result_path
       - store_artifacts: *artifact_storage_path
   build:
@@ -66,6 +71,7 @@ jobs:
           # Test failures should not stop Danger, so hide the exit code.
           command: 'yarn run test:ci && yarn run coveralls || true'
       - run: *full_build
+      - run: *storybook_build
       - run:
           name: DangerCI
           command: yarn run danger

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,7 @@ common_settings:
 
   storybook_build: &storybook_build
     name: Storybook compilation
-    command: yarn workspace @magento/venia-concept run storybook-build
+    command: yarn workspace @magento/venia-concept run storybook:build
 
   test_result_path: &test_result_path
     path: "test-results"

--- a/packages/venia-concept/.storybook/webpack.config.js
+++ b/packages/venia-concept/.storybook/webpack.config.js
@@ -2,9 +2,6 @@ const base_config = require('../webpack.config.js');
 
 module.exports = async storybookBaseConfig => {
     const conf = await base_config();
-    storybookBaseConfig.plugins = conf.plugins.concat(
-        storybookBaseConfig.plugins
-    );
     storybookBaseConfig.module = conf.module;
     storybookBaseConfig.resolve = conf.resolve;
     return storybookBaseConfig;

--- a/packages/venia-concept/webpack.config.js
+++ b/packages/venia-concept/webpack.config.js
@@ -157,7 +157,7 @@ module.exports = async function(env) {
                     // All RootComponents go to prefetch, and all client scripts
                     // go to load.
                     assets.bundles = {
-                        load: assets.entrypoints.client.js,
+                        load: assets.entrypoints.main.js,
                         prefetch: []
                     };
                     Object.entries(assets).forEach(([name, value]) => {

--- a/packages/venia-concept/webpack.config.js
+++ b/packages/venia-concept/webpack.config.js
@@ -157,7 +157,7 @@ module.exports = async function(env) {
                     // All RootComponents go to prefetch, and all client scripts
                     // go to load.
                     assets.bundles = {
-                        load: assets.entrypoints.main.js,
+                        load: assets.entrypoints.client.js,
                         prefetch: []
                     };
                     Object.entries(assets).forEach(([name, value]) => {


### PR DESCRIPTION
## Description
`yarn storybook:venia` is currently throwing an `UnhandledPromiseRejectionWarning: TypeError: Cannot read property 'js' of undefined` in `/pwa-studio/packages/venia-concept/webpack.config.js:160:55)`.

Switching `assets.entrypoints.client.js` to `assets.entrypoints.main.js` solves the issue by pointing `load` at the right entry point location.

## Related Issue
[893](https://github.com/magento-research/pwa-studio/issues/893)

## Motivation and Context
Issue has to be fixed before you can run Storybook for Venia components.

## How Has This Been Tested?
Tested locally.

## Screenshots (if appropriate):
https://imgur.com/a/zb9WnRN

## Proposed Labels for Change Type/Package
BUG, TEST in venia-concept.

## Checklist:
- [ x] I have read the **CONTRIBUTING** document.
- [ x] I have linked an issue to this PR.
- [ x] I have indicated the change type and relevant package(s).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ x] All new and existing tests passed.
- [ ] All CI checks are green (linting, build/deploy, etc).
- [ ] At least one core contributor has approved this PR.
