### PR TITLE
893 - Fixing "yarn storybook:venia" command

### DIFF
--- a/packages/venia-concept/webpack.config.js
+++ b/packages/venia-concept/webpack.config.js
@@ -159,10 +159,11 @@ module.exports = async function(env) {
                     const load = [];
                     const { js, ...entries } = assets.entrypoints;
 
-                    if(Array.isArray(js)) load.push(...js);
+                    if (Array.isArray(js)) load.push(...js);
 
                     Object.keys(entries).forEach(entryName => {
-                        Array.isArray(entries[entryName].js) && load.push(...entries[entryName].js);
+                        Array.isArray(entries[entryName].js) &&
+                            load.push(...entries[entryName].js);
                     });
 
                     assets.bundles = {

--- a/packages/venia-concept/webpack.config.js
+++ b/packages/venia-concept/webpack.config.js
@@ -157,7 +157,7 @@ module.exports = async function(env) {
                     // All RootComponents go to prefetch, and all client scripts
                     // go to load.
                     assets.bundles = {
-                        load: assets.entrypoints.client.js,
+                        load: assets.entrypoints.js,
                         prefetch: []
                     };
                     Object.entries(assets).forEach(([name, value]) => {

--- a/packages/venia-concept/webpack.config.js
+++ b/packages/venia-concept/webpack.config.js
@@ -156,8 +156,17 @@ module.exports = async function(env) {
                 transform(assets) {
                     // All RootComponents go to prefetch, and all client scripts
                     // go to load.
+                    const load = [];
+                    const { js, ...entries } = assets.entrypoints;
+
+                    if(Array.isArray(js)) load.push(...js);
+
+                    Object.keys(entries).forEach(entryName => {
+                        Array.isArray(entries[entryName].js) && load.push(...entries[entryName].js);
+                    });
+
                     assets.bundles = {
-                        load: assets.entrypoints.js,
+                        load,
                         prefetch: []
                     };
                     Object.entries(assets).forEach(([name, value]) => {


### PR DESCRIPTION
## Description
Fixing the `WebpackAssetsManifest` plugin. It was getting a wrong object key, causing an error when `yarn storybook:venia` is executed.

## Related Issue
Closes #893.

## Motivation and Context
It was breaking the storybook execution

## How Has This Been Tested?
As the issue says:

1. Checkout the latest of `release/2.0` branch.
2. `yarn clean:all`
3. `yarn install`
4. `yarn build`
5. `yarn storybook:venia`

## Screenshots:
https://imgur.com/a/ZJ6GcKz
https://imgur.com/Do6w7jk

## Proposed Labels for Change Type/Package
BUG
venia-concept

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] I have linked an issue to this PR.
- [x] I have indicated the change type and relevant package(s).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All CI checks are green (linting, build/deploy, etc).
- [ ] At least one core contributor has approved this PR.
