### PR TITLE
Adds unit tests to cart reducer

### DIFF
--- a/packages/venia-concept/src/components/MiniCart/cartOptions.js
+++ b/packages/venia-concept/src/components/MiniCart/cartOptions.js
@@ -1,5 +1,5 @@
 import React, { Component, Suspense } from 'react';
-import { array, func, number, shape, string } from 'prop-types';
+import { array, bool, func, number, shape, string } from 'prop-types';
 import { Form } from 'informed';
 import { Price } from '@magento/peregrine';
 
@@ -38,6 +38,7 @@ class CartOptions extends Component {
         configItem: shape({
             configurable_options: array
         }),
+        isUpdatingItem: bool,
         updateCart: func.isRequired,
         closeOptionsDrawer: func.isRequired
     };
@@ -88,11 +89,13 @@ class CartOptions extends Component {
 
     render() {
         const { fallback, handleSelectionChange, props } = this;
-        const { classes, cartItem, configItem, isLoading } = props;
+        const { classes, cartItem, configItem, isUpdatingItem } = props;
         const { name, price } = cartItem;
         const { configurable_options } = configItem;
 
-        const modalClass = isLoading ? classes.modal_active : classes.modal;
+        const modalClass = isUpdatingItem
+            ? classes.modal_active
+            : classes.modal;
 
         const options = Array.isArray(configurable_options) ? (
             <Suspense fallback={fallback}>

--- a/packages/venia-concept/src/components/MiniCart/miniCart.js
+++ b/packages/venia-concept/src/components/MiniCart/miniCart.js
@@ -36,8 +36,9 @@ class MiniCart extends Component {
             details: object,
             guestCartId: string,
             totals: object,
+            isLoading: bool,
             isOptionsDrawerOpen: bool,
-            isLoading: bool
+            isUpdatingItem: bool
         }),
         classes: shape({
             body: string,
@@ -182,7 +183,7 @@ class MiniCart extends Component {
                             cartItem={focusItem}
                             configItem={itemWithOptions}
                             closeOptionsDrawer={closeOptionsDrawer}
-                            isLoading={cart.isLoading}
+                            isUpdatingItem={cart.isUpdatingItem}
                             updateCart={updateItemInCart}
                         />
                     );
@@ -193,7 +194,7 @@ class MiniCart extends Component {
                 cartItem={focusItem}
                 configItem={{}}
                 closeOptionsDrawer={closeOptionsDrawer}
-                isLoading={cart.isLoading}
+                isUpdatingItem={cart.isUpdatingItem}
                 updateCart={updateItemInCart}
             />
         );
@@ -234,7 +235,7 @@ class MiniCart extends Component {
         const { miniCartInner, productOptions, props } = this;
         const {
             cancelCheckout,
-            cart: { isOptionsDrawerOpen, loading },
+            cart: { isOptionsDrawerOpen, isLoading },
             classes,
             isMiniCartMaskOpen,
             isOpen
@@ -254,7 +255,7 @@ class MiniCart extends Component {
                         <Icon src={CloseIcon} />
                     </Trigger>
                 </div>
-                {loading ? loadingIndicator : body}
+                {isLoading ? loadingIndicator : body}
                 <Mask isActive={isMiniCartMaskOpen} dismiss={cancelCheckout} />
             </aside>
         );

--- a/packages/venia-concept/src/reducers/__tests__/cart.spec.js
+++ b/packages/venia-concept/src/reducers/__tests__/cart.spec.js
@@ -1,84 +1,203 @@
-import cartReducers, { initialState } from 'src/reducers/cart';
+import reducer, { initialState } from 'src/reducers/cart';
 import actions from 'src/actions/cart';
 import checkoutActions from 'src/actions/checkout';
 
-test('getGuestCart.receive: adds guestCartId to state', () => {
-    expect(
-        cartReducers(
-            { other: 'stuff' },
-            { type: actions.getGuestCart.receive, payload: 'A_CART' }
-        )
-    ).toEqual({
-        other: 'stuff',
-        guestCartId: 'A_CART'
+const state = { ...initialState };
+
+describe('getGuestCart.receive', () => {
+    const actionType = actions.getGuestCart.receive;
+
+    test('it sets guestCartId', () => {
+        const action = {
+            error: null,
+            payload: 1,
+            type: actionType
+        };
+
+        const result = reducer(state, action);
+
+        expect(result).toHaveProperty('guestCartId', 1);
+    });
+
+    test('it restores initial state on error', () => {
+        const action = {
+            error: true,
+            payload: new Error('unit test'),
+            type: actionType
+        };
+
+        const result = reducer(state, action);
+
+        expect(result).toEqual(initialState);
     });
 });
 
-test('getGuestCart.receive: restores initial state on error', () => {
-    expect(
-        cartReducers(
-            { guestCartId: 'AN_EXPIRED_CART', other: 'stuff' },
-            {
-                type: actions.getGuestCart.receive,
-                payload: new Error('Failed to get a guest cart!'),
-                error: true
-            }
-        )
-    ).toEqual(initialState);
-});
+describe('getDetails.request', () => {
+    const actionType = actions.getDetails.request;
 
-test('getGuestCart.receive: adds guestCartId to state', () => {
-    expect(
-        cartReducers(
-            { other: 'stuff' },
-            { type: actions.getGuestCart.receive, payload: 'A_CART' }
-        )
-    ).toEqual({
-        other: 'stuff',
-        guestCartId: 'A_CART'
+    test('it sets guestCartId and the isLoading flag', () => {
+        const action = {
+            payload: 1,
+            type: actionType
+        };
+
+        const result = reducer(state, action);
+
+        expect(result).toHaveProperty('guestCartId', 1);
+        expect(result).toHaveProperty('isLoading', true);
     });
 });
 
-test('getDetails.receive: merges payload with state', () => {
-    expect(
-        cartReducers(
-            { other: 'stuff', totals: { total: 100 } },
-            {
-                type: actions.getDetails.receive,
-                payload: {
-                    totals: { total: 200 },
-                    details: { items: ['woah'] }
-                }
-            }
-        )
-    ).toEqual({
-        loading: false,
-        other: 'stuff',
-        totals: {
-            total: 200
-        },
-        details: {
-            items: ['woah']
-        }
+describe('getDetails.receive', () => {
+    const actionType = actions.getDetails.receive;
+
+    test('it sets isLoading to false and includes all of payload', () => {
+        const action = {
+            payload: { unit: 'test', other: 'stuff' },
+            type: actionType
+        };
+
+        const result = reducer(state, action);
+
+        expect(result).toHaveProperty('isLoading', false);
+        expect(result).toHaveProperty('unit', 'test');
+        expect(result).toHaveProperty('other', 'stuff');
+    });
+
+    test('it sets isLoading to false and guestCartId to null on error', () => {
+        const action = {
+            error: true,
+            payload: new Error('unit test'),
+            type: actionType
+        };
+
+        const result = reducer(state, action);
+
+        expect(result).toHaveProperty('isLoading', false);
+        expect(result).toHaveProperty('guestCartId', null);
     });
 });
 
-test('getDetails.receive: removes guestCartId on error', () => {
-    const state = { guestCartId: 123, other: 'stuff', totals: { total: 100 } };
-    const nextState = cartReducers(state, {
-        type: actions.getDetails.receive,
-        payload: new Error('That did not work at all'),
-        error: true
+describe('updateItem.request', () => {
+    const actionType = actions.updateItem.request;
+
+    test('it sets isUpdatingItem to true and includes all of payload', () => {
+        const action = {
+            payload: { unit: 'test', other: 'stuff' },
+            type: actionType
+        };
+
+        const result = reducer(state, action);
+
+        expect(result).toHaveProperty('isUpdatingItem', true);
+        expect(result).toHaveProperty('unit', 'test');
+        expect(result).toHaveProperty('other', 'stuff');
     });
-    expect(nextState).toMatchObject({ other: 'stuff', totals: { total: 100 } });
-    expect(nextState.guestCartId).not.toBeTruthy();
+
+    test('it returns the initial state on error', () => {
+        const action = {
+            error: true,
+            payload: new Error('unit test'),
+            type: actionType
+        };
+
+        const result = reducer(state, action);
+
+        expect(result).toEqual(initialState);
+    });
 });
 
-test('checkoutActions.order.accept: cart resets to initial state', () => {
-    expect(
-        cartReducers(
-            { guestCartId: 'SOME_CART', details: { items: ['done'] } },
-            { type: checkoutActions.order.accept }
-        )
-    ).toEqual(initialState);
+describe('updateItem.receive', () => {
+    const actionType = actions.updateItem.receive;
+
+    test('it sets isUpdatingItem to false', () => {
+        const action = {
+            type: actionType
+        };
+
+        const result = reducer(state, action);
+
+        expect(result).toHaveProperty('isUpdatingItem', false);
+    });
+});
+
+describe('removeItem.receive', () => {
+    const actionType = actions.removeItem.receive;
+
+    test('it includes all of payload on success', () => {
+        const action = {
+            payload: { unit: 'test', cartItemCount: 5 },
+            type: actionType
+        };
+
+        const result = reducer(state, action);
+
+        expect(result).toHaveProperty('unit', 'test');
+        expect(result).toHaveProperty('cartItemCount', 5);
+    });
+
+    test('it returns the initial state if there is only one item', () => {
+        const action = {
+            payload: { unit: 'test', cartItemCount: 1 },
+            type: actionType
+        };
+
+        const result = reducer(state, action);
+
+        expect(result).toEqual(initialState);
+    });
+
+    test('it returns the initial state on error', () => {
+        const action = {
+            error: true,
+            payload: new Error('unit test'),
+            type: actionType
+        };
+
+        const result = reducer(state, action);
+
+        expect(result).toEqual(initialState);
+    });
+});
+
+describe('openOptionsDrawer', () => {
+    const actionType = actions.openOptionsDrawer;
+
+    test('it sets isOptionsDrawerOpen to true', () => {
+        const action = {
+            type: actionType
+        };
+
+        const result = reducer(state, action);
+
+        expect(result).toHaveProperty('isOptionsDrawerOpen', true);
+    });
+});
+
+describe('closeOptionsDrawer', () => {
+    const actionType = actions.closeOptionsDrawer;
+
+    test('it sets isOptionsDrawerOpen to false', () => {
+        const action = {
+            type: actionType
+        };
+
+        const result = reducer(state, action);
+
+        expect(result).toHaveProperty('isOptionsDrawerOpen', false);
+    });
+});
+
+describe('checkoutActions.order.accept', () => {
+    const actionType = checkoutActions.order.accept;
+
+    test('it returns the initial state', () => {
+        const action = {
+            type: actionType
+        };
+
+        const result = reducer(state, action);
+
+        expect(result).toEqual(initialState);
+    });
 });

--- a/packages/venia-concept/src/reducers/cart.js
+++ b/packages/venia-concept/src/reducers/cart.js
@@ -7,13 +7,13 @@ export const name = 'cart';
 
 export const initialState = {
     details: {},
-    loading: false,
     guestCartId: null,
+    isLoading: false,
+    isOptionsDrawerOpen: false,
+    isUpdatingItem: false,
     paymentMethods: [],
     shippingMethods: [],
-    totals: {},
-    isOptionsDrawerOpen: false,
-    isLoading: false
+    totals: {}
 };
 
 const reducerMap = {
@@ -31,14 +31,14 @@ const reducerMap = {
         return {
             ...state,
             guestCartId: payload,
-            loading: true
+            isLoading: true
         };
     },
     [actions.getDetails.receive]: (state, { payload, error }) => {
         if (error) {
             return {
                 ...state,
-                loading: false,
+                isLoading: false,
                 guestCartId: null
             };
         }
@@ -46,7 +46,7 @@ const reducerMap = {
         return {
             ...state,
             ...payload,
-            loading: false
+            isLoading: false
         };
     },
     [actions.updateItem.request]: (state, { payload, error }) => {
@@ -56,7 +56,15 @@ const reducerMap = {
         return {
             ...state,
             ...payload,
-            isLoading: true
+            isUpdatingItem: true
+        };
+    },
+    [actions.updateItem.receive]: state => {
+        // We don't actually have to update any items here
+        // because we force a refresh from the server.
+        return {
+            ...state,
+            isUpdatingItem: false
         };
     },
     [actions.removeItem.receive]: (state, { payload, error }) => {
@@ -82,8 +90,7 @@ const reducerMap = {
     [actions.closeOptionsDrawer]: state => {
         return {
             ...state,
-            isOptionsDrawerOpen: false,
-            isLoading: false
+            isOptionsDrawerOpen: false
         };
     },
     [checkoutActions.order.accept]: () => {


### PR DESCRIPTION
<!--
Thank you for your contribution!

Before submitting this pull request, please make sure you have read our Contribution Guidelines and your PR meets our contribution standards:
https://github.com/magento-research/pwa-studio/blob/master/.github/CONTRIBUTION.md

Please fill out as much information as you can about your PR to help speed up the review process.
If your PR addresses an existing GitHub Issue, please refer to it in the title or Additional Information section to make the connection.

We may ask you for changes in your PR in order to meet the standards set in our Contribution Guidelines. PRs that do not comply with our guidelines may be closed at the maintainers' discretion.

Feel free to remove this section before creating this PR.
-->

## Description
<!--- Provide a general summary of your changes in the Title above -->
<!--- Describe your changes in detail here: -->

This PR adds unit tests to `reducers/cart.js`.

It also does a little refactoring for sanity sake, as the reducer was returning state containing both a `loading` and an `isLoading`, which were for two completely different purposes. I renamed them and updated any code that needed to reflect the new names.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here with the specific wording: "Closes #<issue>" -->
<!--- Using the above wording causes Github to automatically close the issue on merge. -->
Closes #922 .

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

Part of the ongoing effort to increase unit test coverage in Venia.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
`yarn test`. See that the coverage numbers are at 100%.
## Screenshots (if appropriate):

## Proposed Labels for Change Type/Package
<!--- What types of changes does your code introduce? Let us know if this is a -->
<!--- BUG, FEATURE, DOCUMENTATION, or TEST change. -->
TEST
<!--- What packages are modified by this code? Let us know if this applies to -->
<!--- peregrine, pwa-buildpack, upward-js, upward-spec, venia-concept or pwa-devdocs -->
`venia-concept`

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have linked an issue to this PR.
- [x] I have indicated the change type and relevant package(s).
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All CI checks are green (linting, build/deploy, etc).
- [ ] At least one core contributor has approved this PR.
