### PR TITLE
Adds unit tests to catalog reducer

### DIFF
--- a/packages/venia-concept/src/reducers/__tests__/catalog.spec.js
+++ b/packages/venia-concept/src/reducers/__tests__/catalog.spec.js
@@ -1,0 +1,138 @@
+import reducer, { initialState } from '../catalog';
+import actions from 'src/actions/catalog';
+
+const state = { ...initialState };
+
+describe('getAllCategories.receive', () => {
+    const actionType = actions.getAllCategories.receive;
+
+    test('it sets categories and rootCategoryId', () => {
+        const action = {
+            payload: {
+                childrenData: [],
+                id: 9
+            },
+            type: actionType
+        };
+
+        const result = reducer(state, action);
+
+        expect(result).toHaveProperty('rootCategoryId', 9);
+        expect(result).toHaveProperty('categories', expect.any(Object));
+    });
+
+    test('it does not alter state on error', () => {
+        const action = {
+            error: true,
+            payload: new Error('unit test'),
+            type: actionType
+        };
+
+        const result = reducer(state, action);
+
+        expect(result).toEqual(state);
+    });
+
+    test('it normalizes the categories', () => {
+        const action = {
+            payload: {
+                childrenData: [
+                    { id: 1, childrenData: [] },
+                    { id: 2, childrenData: [] },
+                    {
+                        id: 3,
+                        childrenData: [
+                            { id: 4, childrenData: [] },
+                            { id: 5, childrenData: [] }
+                        ]
+                    }
+                ],
+                id: 9
+            },
+            type: actionType
+        };
+
+        const result = reducer(state, action);
+
+        expect(result).toHaveProperty('categories', {
+            1: {
+                childrenData: [],
+                id: 1
+            },
+            2: {
+                childrenData: [],
+                id: 2
+            },
+            3: {
+                childrenData: [4, 5],
+                id: 3
+            },
+            4: {
+                childrenData: [],
+                id: 4
+            },
+            5: {
+                childrenData: [],
+                id: 5
+            },
+            9: {
+                childrenData: [1, 2, 3],
+                id: 9
+            }
+        });
+    });
+});
+
+describe('setCurrentPage.receive', () => {
+    const actionType = actions.setCurrentPage.receive;
+
+    test('it sets currentPage to payload', () => {
+        const action = {
+            payload: 7,
+            type: actionType
+        };
+
+        const result = reducer(state, action);
+
+        expect(result).toHaveProperty('currentPage', 7);
+    });
+
+    test('it does not alter state on error', () => {
+        const action = {
+            error: true,
+            payload: new Error('unit test'),
+            type: actionType
+        };
+
+        const result = reducer(state, action);
+
+        expect(result).toEqual(state);
+    });
+});
+
+describe('setPrevPageTotal.receive', () => {
+    const actionType = actions.setPrevPageTotal.receive;
+
+    test('it sets prevPageTotal to payload', () => {
+        const action = {
+            payload: 5,
+            type: actionType
+        };
+
+        const result = reducer(state, action);
+
+        expect(result).toHaveProperty('prevPageTotal', 5);
+    });
+
+    test('it does not alter state on error', () => {
+        const action = {
+            error: true,
+            payload: new Error('unit test'),
+            type: actionType
+        };
+
+        const result = reducer(state, action);
+
+        expect(result).toEqual(state);
+    });
+});

--- a/packages/venia-concept/src/reducers/catalog.js
+++ b/packages/venia-concept/src/reducers/catalog.js
@@ -4,7 +4,7 @@ import actions from 'src/actions/catalog';
 
 export const name = 'catalog';
 
-const initialState = {
+export const initialState = {
     categories: null,
     rootCategoryId: null,
     currentPage: 1,


### PR DESCRIPTION
<!--
Thank you for your contribution!

Before submitting this pull request, please make sure you have read our Contribution Guidelines and your PR meets our contribution standards:
https://github.com/magento-research/pwa-studio/blob/master/.github/CONTRIBUTION.md

Please fill out as much information as you can about your PR to help speed up the review process.
If your PR addresses an existing GitHub Issue, please refer to it in the title or Additional Information section to make the connection.

We may ask you for changes in your PR in order to meet the standards set in our Contribution Guidelines. PRs that do not comply with our guidelines may be closed at the maintainers' discretion.

Feel free to remove this section before creating this PR.
-->

## Description
<!--- Provide a general summary of your changes in the Title above -->
<!--- Describe your changes in detail here: -->

This PR adds unit tests for `reducers/catalog.js`

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here with the specific wording: "Closes #<issue>" -->
<!--- Using the above wording causes Github to automatically close the issue on merge. -->
Closes #930 .

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

Increase unit test coverage in Venia.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

`yarn test`. See that `reducers/catalog.js` coverage is at 100%.

## Screenshots (if appropriate):

## Proposed Labels for Change Type/Package
<!--- What types of changes does your code introduce? Let us know if this is a -->
<!--- BUG, FEATURE, DOCUMENTATION, or TEST change. -->
TEST

<!--- What packages are modified by this code? Let us know if this applies to -->
<!--- peregrine, pwa-buildpack, upward-js, upward-spec, venia-concept or pwa-devdocs -->
`venia-concept`

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have linked an issue to this PR.
- [x] I have indicated the change type and relevant package(s).
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All CI checks are green (linting, build/deploy, etc).
- [ ] At least one core contributor has approved this PR.
