### PR TITLE
Accommodate custom attributes

### DIFF
--- a/packages/venia-concept/src/components/ProductOptions/getOptionType.js
+++ b/packages/venia-concept/src/components/ProductOptions/getOptionType.js
@@ -1,0 +1,5 @@
+const customAttributes = {
+    fashion_color: 'swatch'
+};
+
+export default ({ attribute_code: code }) => customAttributes[code];

--- a/packages/venia-concept/src/components/ProductOptions/option.js
+++ b/packages/venia-concept/src/components/ProductOptions/option.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import { arrayOf, func, object, shape, string } from 'prop-types';
 
 import classify from 'src/classify';
+import getOptionType from './getOptionType';
 import SwatchList from './swatchList';
 import TileList from './tileList';
 import defaultClasses from './option.css';
@@ -30,11 +31,13 @@ class Option extends Component {
     };
 
     get listComponent() {
-        const { attribute_code } = this.props;
+        const { attribute_code, values } = this.props;
 
         // TODO: get an explicit field from the API
         // that identifies an attribute as a swatch
-        return attribute_code === 'fashion_color' ? SwatchList : TileList;
+        const optionType = getOptionType({ attribute_code, values });
+
+        return optionType === 'swatch' ? SwatchList : TileList;
     }
 
     render() {

--- a/packages/venia-concept/src/queries/getProductDetail.graphql
+++ b/packages/venia-concept/src/queries/getProductDetail.graphql
@@ -35,9 +35,11 @@ query productDetail($urlKey: String, $onServer: Boolean!) {
                     }
                 }
                 variants {
+                    attributes {
+                        code
+                        value_index
+                    }
                     product {
-                        fashion_color
-                        fashion_size
                         id
                         media_gallery_entries {
                             disabled

--- a/packages/venia-concept/src/queries/getProductDetailByName.graphql
+++ b/packages/venia-concept/src/queries/getProductDetailByName.graphql
@@ -19,9 +19,11 @@ query productDetailByName($name: String, $onServer: Boolean!) {
                     }
                 }
                 variants {
+                    attributes {
+                        code
+                        value_index
+                    }
                     product {
-                        fashion_color
-                        fashion_size
                         id
                         media_gallery_entries {
                             disabled

--- a/packages/venia-concept/src/util/appendOptionsToPayload.js
+++ b/packages/venia-concept/src/util/appendOptionsToPayload.js
@@ -18,11 +18,20 @@ const appendOptionsToPayload = (
         option_value: value
     }));
 
-    const selectedVariant = variants.find(({ product: variant }) => {
+    const selectedVariant = variants.find(({ attributes, product }) => {
         for (const [id, value] of optionSelections) {
             const code = optionCodes.get(id);
 
-            if (variant[code] !== value) {
+            // check `product` for standard attributes
+            // check `attributes` for custom attributes
+            if (
+                product[code] !== value &&
+                !attributes.some(
+                    attribute =>
+                        attribute.code === code &&
+                        attribute.value_index === value
+                )
+            ) {
                 return false;
             }
         }

--- a/packages/venia-concept/src/util/appendOptionsToPayload.js
+++ b/packages/venia-concept/src/util/appendOptionsToPayload.js
@@ -19,7 +19,7 @@ const appendOptionsToPayload = (
     }));
 
     const selectedVariant = variants.find(({ attributes, product }) => {
-        const customAttributes = (attributes, []).reduce(
+        const customAttributes = (attributes || []).reduce(
             (map, { code, value_index }) => new Map(map).set(code, value_index),
             new Map()
         );

--- a/packages/venia-concept/src/util/appendOptionsToPayload.js
+++ b/packages/venia-concept/src/util/appendOptionsToPayload.js
@@ -19,23 +19,26 @@ const appendOptionsToPayload = (
     }));
 
     const selectedVariant = variants.find(({ attributes, product }) => {
+        const customAttributes = (attributes, []).reduce(
+            (map, { code, value_index }) => new Map(map).set(code, value_index),
+            new Map()
+        );
+
         for (const [id, value] of optionSelections) {
             const code = optionCodes.get(id);
+            const matchesStandardAttribute = product[code] === value;
+            const matchesCustomAttribute = customAttributes.get(code) === value;
 
-            // check `product` for standard attributes
-            // check `attributes` for custom attributes
-            if (
-                product[code] !== value &&
-                !attributes.some(
-                    attribute =>
-                        attribute.code === code &&
-                        attribute.value_index === value
-                )
-            ) {
+            // if any option selection fails to match any standard attribute
+            // and also fails to match any custom attribute
+            // then this isn't the correct variant
+            if (!matchesStandardAttribute && !matchesCustomAttribute) {
                 return false;
             }
         }
 
+        // otherwise, every option selection matched
+        // and this is the correct variant
         return true;
     });
 


### PR DESCRIPTION
## Description

Make `venia-concept` less coupled to the Venia sample data by accommodating custom attributes.

## Related Issue

Closes #983.

## Motivation and Context

**Custom attributes in queries**

Venia uses the custom attributes `fashion_color` and `fashion_size`. These product options are required on some configurable products; for such a product, a shopper must select values for these options in order to add the product to her cart. This configured product is called a `variant`.

Our queries include these custom attributes directly, because in Magento 2.3.0 there is no way to retrieve a list of them. In Magento 2.3.1, the `ConfigurableVariant` interface has an `attributes` field, so we can now retrieve that list (and remove `fashion_color` and `fashion_size` from our product queries).

**Attribute type**

There is one remaining area in which `venia-concept` references Venia's custom attributes directly. Within product options, the `Option` component is responsible for determining which component is used to render the list of selectable option values. In both 2.3.0 and 2.3.1, GraphQL does not expose `swatch` as an attribute type, so we check for `fashion_color` specifically and render a `SwatchList` in that case.

Since we still can't get this info from GraphQL, I've isolated that logic to a private function so we can potentially change it in the future without changing the component.

## Verification

Ensure configurable products can be added to cart and purchased.

## How Has This Been Tested?

Pending.