### PR TITLE
fix(ci): Configure CircleCI to build release and master.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,14 +3,17 @@ workflows:
   version: 2
   build-deploy:
     jobs:
-      - build:
+      - pr:
           filters:
             branches:
-              ignore: master
-      - master:
+              ignore: &integration_branches
+                - master
+                - develop
+                - /release\/\d+\.\d+
+      - integration:
           filters:
             branches:
-              only: master
+              only: *integration_branches
 
 # This key means nothing to CircleCI; it's just a place to keep anchored
 # configuration nodes for reuse.
@@ -42,7 +45,7 @@ common_settings:
     path: "packages/venia-concept/dist"
 
 jobs:
-  master:
+  integration:
     docker: *docker_setup
     steps:
       - checkout
@@ -55,9 +58,13 @@ jobs:
           command: yarn run coveralls
       - run: *full_build
       - run: *storybook_build
+      - run:
+          name: Bundle size analysis
+          command: yarn run bundlesize
+
       - store_test_results: *test_result_path
       - store_artifacts: *artifact_storage_path
-  build:
+  pr:
     docker: *docker_setup
     steps:
       - checkout


### PR DESCRIPTION
## Description
Change CircleCI config to more clearly delineate between pull request builds and integration builds:

- Rename `build` workflow to `pr` and `master` workflow to `integration`.
- Change workflow filter rules so that:
    - The `integration` workflow runs on `master`, `develop`, and `release/x.x` branches (using a regular expression for the latter)
    - The `build` workflow excludes those same branches

## Related Issue
Closes #1042.

## Motivation and Context
Releasing 2.1 and future releases.

## Verification
Make sure CircleCI builds for this PR behave as expected, but we won't know for sure until we merge it, due to the nature of CircleCI.


## Proposed Labels for Change Type/Package
<!--- What types of changes does your code introduce? Let us know if this is a -->
<!--- BUG, FEATURE, DOCUMENTATION, or TEST change. -->
BUG for CI workflow.


<!--- What packages are modified by this code? Let us know if this applies to -->
<!--- peregrine, pwa-buildpack, upward-js, upward-spec, venia-concept or pwa-devdocs -->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have linked an issue to this PR.
- [x] I have indicated the change type and relevant package(s).
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All CI checks are green (linting, build/deploy, etc).
- [ ] At least one core contributor has approved this PR.
