### PR TITLE
bug: Add / to graphql validation endpoint

### DIFF
--- a/packages/venia-concept/.graphqlconfig
+++ b/packages/venia-concept/.graphqlconfig
@@ -4,7 +4,7 @@
             "schemaPath": "lastCachedGraphQLSchema.json",
             "extensions": {
                 "endpoints": {
-                    "default": "${env:MAGENTO_BACKEND_URL}graphql"
+                    "default": "${env:MAGENTO_BACKEND_URL}/graphql"
                 },
                 "validate-magento-pwa-queries": {
                     "clients": ["apollo", "literal"],


### PR DESCRIPTION
## Description
The graphql validation endpoint we added in #1004 did not have a `/`. Since we don't mandate that the `MAGENTO_BACKEND_URL` end with a forward slash we should add one here to be safe.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

```js
$ yarn run download-schema && graphql validate-magento-pwa-queries --project venia
$ graphql get-schema --project venia
⚠ request to https://release-dev-231-npzdaky-zddsyhrdimyra.us-4.magentosite.cloudgraphql failed, reason: getaddrinfo ENOTFOUND release-dev-231-npzdaky-zddsyhrdimyra.us-4.magentosite.cloudgraphql release-dev-231-npzdaky-zddsyhrdimyra.us-4.magentosite.cloudgraphql:443
Validating GraphQL queries in venia project...
✖ An error occurred:
Could not find a schema at lastCachedGraphQLSchema.json.
 Run `graphql get-schema --project venia` to download the schema before running validate-magento-pwa-queries.
error Command failed with exit code 1.
```

## Verification
To verify, set the `MAGENT_BACKEND_URL` in your `.env` to something without a `/` like `MAGENTO_BACKEND_URL="https://release-dev-231-npzdaky-zddsyhrdimyra.us-4.magentosite.cloud"`

Then from root run `yarn run validate-queries`. It should fail.
Then check out this PR and run it again, and it should pass.


## How Has This Been Tested?
Above verification. Also tested with url ending with `/`.

## Screenshots (if appropriate):


## Proposed Labels for Change Type/Package
<!--- What types of changes does your code introduce? Let us know if this is a -->
<!--- BUG, FEATURE, DOCUMENTATION, or TEST change. -->


<!--- What packages are modified by this code? Let us know if this applies to -->
<!--- peregrine, pwa-buildpack, upward-js, upward-spec, venia-concept or pwa-devdocs -->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have linked an issue to this PR.
- [x] I have indicated the change type and relevant package(s).
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All CI checks are green (linting, build/deploy, etc).
- [x] At least one core contributor has approved this PR.
