### PR TITLE
feat(upward): add UrlResolver and tests. Closes #1057

### DIFF
--- a/packages/upward-js/lib/resolvers/ProxyResolver.js
+++ b/packages/upward-js/lib/resolvers/ProxyResolver.js
@@ -27,26 +27,26 @@ class ProxyResolver extends AbstractResolver {
                 ? this.visitor.upward(definition, 'ignoreSSLErrors')
                 : false
         ];
-        const [target, ignoreSSLErrors] = await Promise.all(toResolve);
+        const [targetUrl, ignoreSSLErrors] = await Promise.all(toResolve);
 
-        debug('resolved target %o', target);
-        if (typeof target !== 'string') {
+        debug('resolved target %o', targetUrl);
+        if (typeof targetUrl !== 'string' && !targetUrl.href) {
             throw new Error(
-                `'target' argument to ProxyResolver must be a string URL, but was a: ${typeof target}`
+                `'target' argument to ProxyResolver must be a string or URL object, but was a: ${typeof targetUrl}`
             );
         }
 
-        let server = ProxyResolver.servers.get(target);
+        let server = ProxyResolver.servers.get(targetUrl);
         if (!server) {
-            debug(`creating new server for ${target}`);
+            debug(`creating new server for ${targetUrl}`);
             server = proxyMiddleware({
-                target,
+                target: targetUrl.toString(),
                 secure: !ignoreSSLErrors,
                 changeOrigin: true,
                 autoRewrite: true,
                 cookieDomainRewrite: ''
             });
-            ProxyResolver.servers.set(target, server);
+            ProxyResolver.servers.set(targetUrl, server);
         }
 
         return server;

--- a/packages/upward-js/lib/resolvers/ServiceResolver.js
+++ b/packages/upward-js/lib/resolvers/ServiceResolver.js
@@ -10,7 +10,17 @@ class ServiceResolver extends AbstractResolver {
         return 'service';
     }
     static get telltale() {
-        return 'url';
+        return 'endpoint';
+    }
+    static recognize(definition) {
+        // handle deprecated url property for now
+        if (definition.hasOwnProperty('url')) {
+            const newDefinition = Object.assign({}, definition, {
+                endpoint: definition.url
+            });
+            delete newDefinition.url;
+            return newDefinition;
+        }
     }
     async resolve(definition) {
         const die = msg => {
@@ -20,15 +30,21 @@ class ServiceResolver extends AbstractResolver {
                 })}.\n\n${msg}`
             );
         };
-        if (!definition.url) {
-            die('No URL specified.');
+        if (definition.endpoint && definition.url) {
+            die(
+                'Cannot specify both "url" and "endpoint" parameters. The "url" parameter is deprecated; use "endpoint" instead.'
+            );
         }
+        if (!definition.endpoint && !definition.url) {
+            die('No endpoint specified.');
+        }
+        const endpointProp = definition.endpoint ? 'endpoint' : 'url';
         if (!definition.query) {
             die('No GraphQL query document specified.');
         }
         debug('validated config %o', definition);
         const toResolve = [
-            this.visitor.upward(definition, 'url'),
+            this.visitor.upward(definition, endpointProp),
             this.visitor.upward(definition, 'query'),
             definition.method
                 ? this.visitor.upward(definition, 'method')
@@ -41,7 +57,7 @@ class ServiceResolver extends AbstractResolver {
                 : {}
         ];
 
-        const [url, query, method, headers, variables] = await Promise.all(
+        const [endpoint, query, method, headers, variables] = await Promise.all(
             toResolve
         );
 
@@ -49,10 +65,10 @@ class ServiceResolver extends AbstractResolver {
             die(`Variables must resolve to a plain object.`);
         }
 
-        debug('url retrieved: "%s", query resolved, creating link', url);
+        debug('url retrieved: "%s", query resolved, creating link', endpoint);
 
         const link = new HttpLink({
-            uri: url.toString(),
+            uri: endpoint.toString(),
             fetch: this.visitor.io.networkFetch,
             headers,
             useGETForQueries: method === 'GET'
@@ -86,13 +102,8 @@ class ServiceResolver extends AbstractResolver {
                 }
             })
             .catch(e => {
-                if (
-                    e.message.indexOf('Only absolute URLs are supported') !== -1
-                ) {
-                    throw new Error(url.toString() + 'invalid: ' + e.stack);
-                }
                 throw new Error(
-                    `ServiceResolver: Request to ${url.toString()} failed: ${e}`
+                    `ServiceResolver: Request to ${endpoint.toString()} failed: ${e}`
                 );
             });
     }

--- a/packages/upward-js/lib/resolvers/ServiceResolver.js
+++ b/packages/upward-js/lib/resolvers/ServiceResolver.js
@@ -52,7 +52,7 @@ class ServiceResolver extends AbstractResolver {
         debug('url retrieved: "%s", query resolved, creating link', url);
 
         const link = new HttpLink({
-            uri: url,
+            uri: url.toString(),
             fetch: this.visitor.io.networkFetch,
             headers,
             useGETForQueries: method === 'GET'
@@ -91,7 +91,9 @@ class ServiceResolver extends AbstractResolver {
                 ) {
                     throw new Error(url.toString() + 'invalid: ' + e.stack);
                 }
-                throw e;
+                throw new Error(
+                    `ServiceResolver: Request to ${url.toString()} failed: ${e}`
+                );
             });
     }
 }

--- a/packages/upward-js/lib/resolvers/UrlResolver.js
+++ b/packages/upward-js/lib/resolvers/UrlResolver.js
@@ -1,0 +1,103 @@
+const debug = require('debug')('upward-js:UrlResolver');
+const { inspect } = require('util');
+const { URL, URLSearchParams } = require('url');
+const { forOwn, fromPairs, isPlainObject } = require('lodash');
+const AbstractResolver = require('./AbstractResolver');
+
+// The WHATWG URL object can't deal with relative URLs.
+const randomString = Math.random()
+    .toString(36)
+    .slice(2, 7);
+const FAKE_BASE_URL = new URL(`https://upward-fake-${randomString}.localhost`);
+const NON_RELATIVE_PARTS = ['protocol', 'port', 'username', 'password'];
+class UrlResolver extends AbstractResolver {
+    static get resolverType() {
+        return 'url';
+    }
+    static get telltale() {
+        return 'baseUrl';
+    }
+    async resolve(definition) {
+        const die = msg => {
+            throw new Error(
+                `Invalid arguments to UrlResolver: ${inspect(definition, {
+                    compact: false
+                })}.\n\n${msg}`
+            );
+        };
+        if (!definition.hasOwnProperty('baseUrl')) {
+            die(
+                'No baseUrl specified. If the URL must be relative or requires no baseUrl, `baseUrl` must be explicitly set to false.'
+            );
+        }
+        debug('validated config %o', definition);
+
+        const argued = [
+            'baseUrl',
+            'protocol',
+            'hostname',
+            'pathname',
+            'query',
+            'password',
+            'port',
+            'username'
+        ]
+            .filter(arg => definition.hasOwnProperty(arg))
+            .map(async arg => [
+                arg,
+                await this.visitor.upward(definition, arg)
+            ]);
+
+        const { baseUrl, pathname, query, search, ...parts } = fromPairs(
+            await Promise.all(argued)
+        );
+        const base = new URL(baseUrl && baseUrl.toString(), FAKE_BASE_URL);
+
+        const params = new URLSearchParams(search || base.search);
+        if (query) {
+            if (!isPlainObject(query)) {
+                die("'query' must resolve to a plain object");
+            }
+            forOwn(query, (value, name) => {
+                params.set(name, value);
+            });
+        }
+
+        const resultUrl = pathname ? new URL(pathname, base) : base;
+
+        Object.assign(resultUrl, parts);
+
+        const paramsString = params.toString();
+        if (paramsString) {
+            resultUrl.search = '?' + paramsString;
+        }
+
+        if (resultUrl.hostname === FAKE_BASE_URL.hostname) {
+            // Make sure nothing is trying to set an origin property on a
+            // URL meant to be relative.
+            const nonRelativeArguments = NON_RELATIVE_PARTS.filter(prop =>
+                parts.hasOwnProperty(prop)
+            );
+            if (nonRelativeArguments.length > 0) {
+                die(
+                    `Cannot set origin parameters "${nonRelativeArguments}" without setting hostname or baseUrl`
+                );
+            }
+            // Make a fake root-relative URL, including leading slash.
+            const relativeUrl = resultUrl.href.slice(
+                FAKE_BASE_URL.href.length - 1
+            );
+            return {
+                pathname: resultUrl.pathname,
+                search: resultUrl.search,
+                hash: resultUrl.hash,
+                href: relativeUrl,
+                toString: () => relativeUrl
+            };
+        }
+
+        return resultUrl;
+    }
+}
+
+module.exports = UrlResolver;

--- a/packages/upward-js/lib/resolvers/UrlResolver.js
+++ b/packages/upward-js/lib/resolvers/UrlResolver.js
@@ -4,7 +4,9 @@ const { URL, URLSearchParams } = require('url');
 const { forOwn, fromPairs, isPlainObject } = require('lodash');
 const AbstractResolver = require('./AbstractResolver');
 
-// The WHATWG URL object can't deal with relative URLs.
+// The WHATWG URL object can't deal with relative URLs. When baseURL is false,
+// generate a nonce random domain so that we can use the URL object to format.
+// We'll remove it at the end to yield a relative URL back.
 const randomString = Math.random()
     .toString(36)
     .slice(2, 7);
@@ -69,7 +71,7 @@ class UrlResolver extends AbstractResolver {
 
         const paramsString = params.toString();
         if (paramsString) {
-            resultUrl.search = '?' + paramsString;
+            resultUrl.search = paramsString;
         }
 
         if (resultUrl.hostname === FAKE_BASE_URL.hostname) {

--- a/packages/upward-js/lib/resolvers/__tests__/ServiceResolver.test.js
+++ b/packages/upward-js/lib/resolvers/__tests__/ServiceResolver.test.js
@@ -1,28 +1,85 @@
 const ServiceResolver = require('../ServiceResolver');
 const GraphQLDocument = require('../../compiledResources/GraphQLDocument');
 
+const mockVisitor = ({ defs, res }) => ({
+    upward: jest.fn((dfn, name) => defs[dfn[name]]),
+    io: {
+        networkFetch: jest.fn(async () => ({
+            json: async () => res,
+            text: async () => JSON.stringify(res)
+        }))
+    }
+});
+
+const nullVisitor = {};
+
 test('resolverType is service', () =>
     expect(ServiceResolver.resolverType).toBe('service'));
 
 test('telltale exists', () => expect(ServiceResolver.telltale).toBeDefined());
 
-test('places a server call and returns results', async () => {
-    const res = { data: { foo: { bar: 'exam' } } };
-    const visitor = {
-        upward: jest.fn(
-            (dfn, name) =>
-                ({
-                    theUrl: 'https://example.com/graphql',
-                    theQuery: '{ foo { bar } }'
-                }[dfn[name]])
-        ),
-        io: {
-            networkFetch: jest.fn(async () => ({
-                json: async () => res,
-                text: async () => JSON.stringify(res)
-            }))
+test('.recognize identifies and returns a valid configuration', () => {
+    expect(
+        ServiceResolver.recognize({
+            url: 'https://sub.example.com/gql',
+            query: 'query placeholder',
+            variables: {
+                some: 'variable'
+            }
+        })
+    ).toEqual({
+        endpoint: 'https://sub.example.com/gql',
+        query: 'query placeholder',
+        variables: {
+            some: 'variable'
         }
+    });
+    expect(
+        ServiceResolver.recognize({
+            inline: 'gluh'
+        })
+    ).not.toBeDefined();
+});
+
+test('places a server call and returns results', async () => {
+    const defs = {
+        theEndpoint: 'https://example.com/graphql',
+        theQuery: '{ foo { bar } }'
     };
+    const res = { data: { foo: { bar: 'exam' } } };
+    const visitor = mockVisitor({
+        defs,
+        res
+    });
+
+    await expect(
+        new ServiceResolver(visitor).resolve({
+            endpoint: 'theEndpoint',
+            query: 'theQuery'
+        })
+    ).resolves.toEqual(res);
+
+    const [fetchUri, fetchOptions] = visitor.io.networkFetch.mock.calls[0];
+
+    expect(fetchUri).toBe(defs.theEndpoint);
+
+    expect(JSON.parse(fetchOptions.body)).toMatchObject({
+        operationName: null,
+        query: `{\n  foo {\n    bar\n  }\n}\n`,
+        variables: {}
+    });
+});
+
+test('recognizes deprecated "url" parameter', async () => {
+    const defs = {
+        theUrl: 'https://example.com/graphql',
+        theQuery: '{ foo { bar } }'
+    };
+    const res = { data: { foo: { bar: 'exam' } } };
+    const visitor = mockVisitor({
+        defs,
+        res
+    });
 
     await expect(
         new ServiceResolver(visitor).resolve({
@@ -33,43 +90,30 @@ test('places a server call and returns results', async () => {
 
     const [fetchUri, fetchOptions] = visitor.io.networkFetch.mock.calls[0];
 
-    expect(fetchUri).toBe('https://example.com/graphql');
+    expect(fetchUri).toBe(defs.theUrl);
 
     expect(JSON.parse(fetchOptions.body)).toMatchObject({
         operationName: null,
-        query: `{
-  foo {
-    bar
-  }
-}
-`,
+        query: `{\n  foo {\n    bar\n  }\n}\n`,
         variables: {}
     });
 });
 
 test('places a server call with custom method and headers', async () => {
     const res = { data: { foo: { bar: 'exam' } } };
-    const visitor = {
-        upward: jest.fn(
-            (dfn, name) =>
-                ({
-                    theUrl: 'https://example.com/graphql',
-                    theHeaders: { Authorization: 'Bear OMG' },
-                    theMethod: 'GET',
-                    theQuery: '{ foo { bar } }'
-                }[dfn[name]])
-        ),
-        io: {
-            networkFetch: jest.fn(async () => ({
-                json: async () => res,
-                text: async () => JSON.stringify(res)
-            }))
-        }
-    };
+    const visitor = mockVisitor({
+        defs: {
+            theUrl: 'https://example.com/graphql',
+            theHeaders: { Authorization: 'Bear OMG' },
+            theMethod: 'GET',
+            theQuery: '{ foo { bar } }'
+        },
+        res
+    });
 
     await expect(
         new ServiceResolver(visitor).resolve({
-            url: 'theUrl',
+            endpoint: 'theUrl',
             query: 'theQuery',
             headers: 'theHeaders',
             method: 'theMethod'
@@ -85,29 +129,20 @@ test('places a server call with custom method and headers', async () => {
 
 test('places a server call with variables', async () => {
     const res = { data: { foo: { bar: 'nothing' } } };
-    const visitor = {
-        upward: jest.fn(
-            (dfn, name) =>
-                ({
-                    theUrl: 'https://example.com/graphql',
-                    theQuery:
-                        'query getFoo($id: String!) { foo(id: $id) { bar } }',
-                    'combination.to.my.luggage': {
-                        id: 12345
-                    }
-                }[dfn[name]])
-        ),
-        io: {
-            networkFetch: jest.fn(async () => ({
-                json: async () => res,
-                text: async () => JSON.stringify(res)
-            }))
-        }
-    };
+    const visitor = mockVisitor({
+        defs: {
+            theUrl: 'https://example.com/graphql',
+            theQuery: 'query getFoo($id: String!) { foo(id: $id) { bar } }',
+            'combination.to.my.luggage': {
+                id: 12345
+            }
+        },
+        res
+    });
 
     await expect(
         new ServiceResolver(visitor).resolve({
-            url: 'theUrl',
+            endpoint: 'theUrl',
             query: 'theQuery',
             variables: 'combination.to.my.luggage'
         })
@@ -117,12 +152,7 @@ test('places a server call with variables', async () => {
 
     expect(JSON.parse(fetchOptions.body)).toMatchObject({
         operationName: 'getFoo',
-        query: `query getFoo($id: String!) {
-  foo(id: $id) {
-    bar
-  }
-}
-`,
+        query: `query getFoo($id: String!) {\n  foo(id: $id) {\n    bar\n  }\n}\n`,
         variables: {
             id: 12345
         }
@@ -130,41 +160,31 @@ test('places a server call with variables', async () => {
 });
 
 test('throws if variables are in an unacceptable format', async () => {
-    const visitor = {
-        io: {
-            networkFetch: jest.fn(async () => ({
-                json: async () => res,
-                text: async () => JSON.stringify(res)
-            }))
-        },
-        upward: jest.fn(async () => 'bleh')
-    };
-
+    const visitor = mockVisitor({
+        defs: {
+            theUrl: 'https://example.com',
+            theQuery: '{ foo { bar } }',
+            bleh: 'bleh'
+        }
+    });
     await expect(
         new ServiceResolver(visitor).resolve({
-            url: 'theUrl',
+            endpoint: 'theUrl',
             query: 'theQuery',
-            variables: {
-                inline: 'bleh'
-            }
+            variables: 'bleh'
         })
     ).rejects.toThrow('Variables must resolve to a plain object.');
 });
 
 test('throws if variables are in an unacceptable format', async () => {
-    const visitor = {
-        io: {
-            networkFetch: jest.fn(async () => ({
-                json: async () => res,
-                text: async () => JSON.stringify(res)
-            }))
-        },
-        upward: jest.fn(async () => 'bleh')
-    };
-
+    const visitor = mockVisitor({
+        defs: {
+            'combination.to.my.luggage': 12345
+        }
+    });
     await expect(
         new ServiceResolver(visitor).resolve({
-            url: 'theUrl',
+            endpoint: 'theUrl',
             query: 'theQuery',
             variables: 'combination.to.my.luggage'
         })
@@ -172,85 +192,118 @@ test('throws if variables are in an unacceptable format', async () => {
 });
 
 test('throws if query is missing', async () => {
-    const visitor = {
-        io: {
-            networkFetch: jest.fn(async () => ({
-                json: async () => res,
-                text: async () => JSON.stringify(res)
-            }))
-        }
-    };
-
     await expect(
-        new ServiceResolver(visitor).resolve({
-            url: 'theUrl'
+        new ServiceResolver(nullVisitor).resolve({
+            endpoint: 'theUrl'
         })
     ).rejects.toThrow('No GraphQL query');
 });
 
-test('throws if url is missing', async () => {
-    const visitor = {
-        io: {
-            networkFetch: jest.fn(async () => ({
-                json: async () => res,
-                text: async () => JSON.stringify(res)
-            }))
-        }
-    };
-
+test('throws if url and endpoint are missing', async () => {
     await expect(
-        new ServiceResolver(visitor).resolve({
+        new ServiceResolver(nullVisitor).resolve({
             query: 'theQuery'
         })
-    ).rejects.toThrow('No URL');
+    ).rejects.toThrow('No endpoint');
+});
+
+test('throws if url and endpoint are missing', async () => {
+    await expect(
+        new ServiceResolver(nullVisitor).resolve({
+            query: 'theQuery'
+        })
+    ).rejects.toThrow('No endpoint');
+});
+
+test('throws if url and endpoint are both present', async () => {
+    await expect(
+        new ServiceResolver(nullVisitor).resolve({
+            query: 'theQuery',
+            url: 'someUrl',
+            endpoint: 'someEndpoint'
+        })
+    ).rejects.toThrow('Cannot specify both');
 });
 
 test('accepts a precompiled GraphQLDocument', async () => {
     const res = { data: { foo: { bar: 'exam' } } };
     const gqlDoc = new GraphQLDocument('{ foo { bar } }');
     await gqlDoc.compile();
-    const visitor = {
-        upward: jest.fn(
-            (dfn, name) =>
-                ({
-                    theUrl: 'https://example.com/graphql',
-                    theQuery: gqlDoc
-                }[dfn[name]])
-        ),
-        io: {
-            networkFetch: jest.fn(async () => ({
-                json: async () => res,
-                text: async () => JSON.stringify(res)
-            }))
-        }
-    };
+    const visitor = mockVisitor({
+        defs: {
+            theUrl: 'https://example.com/graphql',
+            theQuery: gqlDoc
+        },
+        res
+    });
 
     await expect(
         new ServiceResolver(visitor).resolve({
-            url: 'theUrl',
+            endpoint: 'theUrl',
             query: 'theQuery'
         })
     ).resolves.toEqual(res);
 });
 
 test('throws if the query is neither a string nor a GraphQLDocument', async () => {
-    const visitor = {
-        upward: jest.fn(
-            (dfn, name) =>
-                ({
-                    theUrl: 'https://example.com/graphql',
-                    theQuery: {}
-                }[dfn[name]])
-        ),
-        io: {
-            networkFetch: jest.fn()
+    const visitor = mockVisitor({
+        defs: {
+            theUrl: 'https://example.com/graphql',
+            theQuery: {}
         }
-    };
+    });
 
     await expect(
         new ServiceResolver(visitor).resolve({
-            url: 'theUrl',
+            endpoint: 'theUrl',
             query: 'theQuery'
         })
     ).rejects.toThrowError('Unknown type');
+});
+
+test('throws if GraphQL query returns errors', async () => {
+    const defs = {
+        theEndpoint: 'https://example.com/graphql',
+        theQuery: '{ foo { bar } }'
+    };
+    const res = {
+        errors: [
+            {
+                message: 'A terrible error occurred.'
+            },
+            {
+                message: 'Another terrible error occurred.'
+            }
+        ]
+    };
+    const visitor = mockVisitor({
+        defs,
+        res
+    });
+
+    await expect(
+        new ServiceResolver(visitor).resolve({
+            endpoint: 'theEndpoint',
+            query: 'theQuery'
+        })
+    ).rejects.toThrow('A terrible error occurred');
+});
+
+test('throws if GraphQL request throws', async () => {
+    const defs = {
+        theEndpoint: '/path/to/graphql',
+        theQuery: '{ foo { bar } }'
+    };
+    const visitor = mockVisitor({
+        defs
+    });
+
+    visitor.io.networkFetch = () => Promise.reject('The worst');
+
+    await expect(
+        new ServiceResolver(visitor).resolve({
+            endpoint: 'theEndpoint',
+            query: 'theQuery'
+        })
+    ).rejects.toThrow('The worst');
 });

--- a/packages/upward-js/lib/resolvers/__tests__/ServiceResolver.test.js
+++ b/packages/upward-js/lib/resolvers/__tests__/ServiceResolver.test.js
@@ -1,7 +1,7 @@
 const ServiceResolver = require('../ServiceResolver');
 const GraphQLDocument = require('../../compiledResources/GraphQLDocument');
 
-test('resolverType is file', () =>
+test('resolverType is service', () =>
     expect(ServiceResolver.resolverType).toBe('service'));
 
 test('telltale exists', () => expect(ServiceResolver.telltale).toBeDefined());

--- a/packages/upward-js/lib/resolvers/__tests__/UrlResolver.test.js
+++ b/packages/upward-js/lib/resolvers/__tests__/UrlResolver.test.js
@@ -1,0 +1,106 @@
+const UrlResolver = require('../UrlResolver');
+
+test('resolverType is url', () => expect(UrlResolver.resolverType).toBe('url'));
+
+test('telltale exists', () => expect(UrlResolver.telltale).toBeDefined());
+
+test('formats a relative url', async () => {
+    const pathname = '/relative/path';
+    const search = '?foo=bar';
+    const href = pathname + search;
+    const visitor = {
+        upward: jest.fn(
+            (dfn, name) =>
+                ({
+                    baseUrl: false,
+                    query: {
+                        foo: 'bar'
+                    },
+                    pathname
+                }[dfn[name]])
+        ),
+        io: {}
+    };
+
+    const relativeUrl = await new UrlResolver(visitor).resolve({
+        baseUrl: 'baseUrl',
+        pathname: 'pathname',
+        query: 'query'
+    });
+    expect(relativeUrl.toString()).toBe(href);
+    expect(relativeUrl).toMatchObject({
+        href,
+        pathname,
+        search
+    });
+});
+
+test('formats an absolute url', async () => {
+    const baseUrl = 'https://localhost:8976/rootAbsolute/path?foo=bar';
+    const visitor = {
+        upward: jest.fn(
+            (dfn, name) =>
+                ({
+                    baseUrl,
+                    port: 8888,
+                    query: {
+                        baz: 'quux'
+                    }
+                }[dfn[name]])
+        ),
+        io: {}
+    };
+
+    const absoluteUrl = await new UrlResolver(visitor).resolve({
+        baseUrl: 'baseUrl',
+        port: 'port',
+        query: 'query'
+    });
+    expect(absoluteUrl.toString()).toBe(
+        'https://localhost:8888/rootAbsolute/path?foo=bar&baz=quux'
+    );
+});
+
+test('errors on missing arguments', async () => {
+    await expect(new UrlResolver({ visitor: {} }).resolve({})).rejects.toThrow(
+        'baseUrl'
+    );
+});
+
+test('errors on invalid arguments', async () => {
+    const visitor = {
+        upward: jest.fn(
+            (dfn, name) =>
+                ({
+                    baseUrl: 'https://0.0.0.0',
+                    query: []
+                }[dfn[name]])
+        ),
+        io: {}
+    };
+    await expect(
+        new UrlResolver(visitor).resolve({
+            baseUrl: 'baseUrl',
+            query: 'query'
+        })
+    ).rejects.toThrow('plain object');
+});
+
+test('errors when setting origin properties with no hostname or base', async () => {
+    const visitor = {
+        upward: jest.fn(
+            (dfn, name) =>
+                ({
+                    baseUrl: false,
+                    port: '8999'
+                }[dfn[name]])
+        ),
+        io: {}
+    };
+    await expect(
+        new UrlResolver(visitor).resolve({
+            baseUrl: 'baseUrl',
+            port: 'port'
+        })
+    ).rejects.toThrow('set origin parameters');
+});

--- a/packages/upward-js/lib/resolvers/__tests__/index.test.js
+++ b/packages/upward-js/lib/resolvers/__tests__/index.test.js
@@ -15,6 +15,7 @@ test('Resolvers exports', () => {
         inline: expect.any(Function),
         proxy: expect.any(Function),
         service: expect.any(Function),
-        template: expect.any(Function)
+        template: expect.any(Function),
+        url: expect.any(Function)
     });
 });

--- a/packages/upward-js/lib/resolvers/index.js
+++ b/packages/upward-js/lib/resolvers/index.js
@@ -6,7 +6,8 @@ const ResolverList = [
     require('./ServiceResolver'),
     require('./ProxyResolver'),
     require('./DirectoryResolver'),
-    require('./ConditionalResolver')
+    require('./ConditionalResolver'),
+    require('./UrlResolver')
 ];
 
 const ResolversByType = ResolverList.reduce((out, Resolver) => {

--- a/packages/upward-spec/README.md
+++ b/packages/upward-spec/README.md
@@ -11,7 +11,7 @@ See [UPWARD_MAGENTO.md](UPWARD_MAGENTO.md) for context on how UPWARD fills a nee
 - [UPWARD Specification](#upward-specification)
   - [Quickstart](#quickstart)
   - [Summary](#summary)
-    - [Simple example](#simple-example)
+    - [Echo Example](#echo-example)
   - [Configuration](#configuration)
   - [Responding to requests](#responding-to-requests)
     - [Execution scheduling and ordering](#execution-scheduling-and-ordering)
@@ -53,6 +53,10 @@ See [UPWARD_MAGENTO.md](UPWARD_MAGENTO.md) for context on how UPWARD fills a nee
     - [DirectoryResolver](#directoryresolver)
       - [DirectoryResolver Example](#directoryresolver-example)
       - [DirectoryResolver Configuration Options](#directoryresolver-configuration-options)
+    - [UrlResolver](#urlresolver)
+      - [UrlResolver Example](#urlresolver-example)
+      - [UrlResolver Configuration Options](#urlresolver-configuration-options)
+      - [UrlResolver Notes](#urlresolver-notes)
   - [Reducing boilerplate](#reducing-boilerplate)
     - [Default parameters](#default-parameters)
     - [Builtin constants](#builtin-constants)
@@ -654,7 +658,7 @@ documentResult:
 | `url`       | `Resolved<string>`                | `https://localhost/graphql` | :no_entry_sign: _**Deprecated**_. Synonymous with `endpoint`. Replaced with `endpoint` for readability. This parameter is still supported for now, but should be replaced with `endpoint`. If both are present, an error will be thrown. |
 | `method`    | `Resolved<string>`                | `POST`                      | The HTTP method to use. While GraphQL queries are typically POSTS, some services expose GraphQL over GET instead.                                                                                                                        |
 | `headers`   | `Resolved<Object<string,string>>` |                             | Additional HTTP headers to send with the GraphQL request. Some headers are set automatically, but the `headers` configuration can append to headers that can have multiple values.                                                       |
-| `query`     | `Resolved<Query|string>`          |                             | _Required_. The GraphQL query object. Can either be a parsed query, or a string that can be parsed as a valid query.                                                                                                                     |
+| `query`     | `Resolved<Query\|string>`         |                             | _Required_. The GraphQL query object. Can either be a parsed query, or a string that can be parsed as a valid query.                                                                                                                     |
 | `variables` | `Resolved<Object<any>>`           | `{}`                        | Variables to use with the GraphQL query. Must resolve to an object with keys and values, almost always with an InlineResolver.                                                                                                           |
 
 **ServiceResolvers always use GraphQL.** To obtain data from a non-GraphQL service, an UPWARD server may implement client-side directives which change the behavior of a GraphQL query, such as [apollo-link-rest][apollo-link-rest], and place the directives in the query itself. This should be transparent to the UPWARD server itself, which delegates the service call to a GraphQL client. If an UPWARD server's GraphQL client has no implementation for such a directive, then it must pass the query unmodified to the backing service to handle the directive.
@@ -744,11 +748,11 @@ The above configuration resolves into an HTML document displaying content from t
 
 #### TemplateResolver Configuration Options
 
-| Property   | Type                                | Default | Description                                                                                                                                                                   |
-| ---------- | ----------------------------------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `engine`   | `Resolved<string>`                  |         | _Required_. The label of the template engine to use.                                                                                                                          |
-| `provide`  | `Resolved<string[]|object<string>>` |         | _Required._ A list, or an object mapping, of values to make available in the template. Passing the entire context to a template for evaluation can cause cyclic dependencies. |
-| `template` | `Resolved<Template|string>`         |         | The template to render.                                                                                                                                                       |
+| Property   | Type                                 | Default | Description                                                                                                                                                                   |
+| ---------- | ------------------------------------ | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `engine`   | `Resolved<string>`                   |         | _Required_. The label of the template engine to use.                                                                                                                          |
+| `provide`  | `Resolved<string[]\|object<string>>` |         | _Required._ A list, or an object mapping, of values to make available in the template. Passing the entire context to a template for evaluation can cause cyclic dependencies. |
+| `template` | `Resolved<Template\\|string>`        |         | The template to render.                                                                                                                                                       |
 
 #### Template Context
 
@@ -1037,17 +1041,17 @@ https://admin.host:8081/api/rest/v1/adminToken?refreshToken=a1b2c3&role=owner
 
 #### UrlResolver Configuration Options
 
-| Property   | Type                       | Default  | Description                                                                                                                                                                                         |
-| ---------- | -------------------------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `baseUrl`  | `Resolved<string|boolean>` |          | _Required_. The base URL to use for constructing the new URL. Must be `false` if no base URL is required.                                                                                           |
-| `hash`     | `Resolved<string>`         |          | Hash fragment of the URL, beginning with `#`.                                                                                                                                                       |
-| `hostname` | `Resolved<string>`         |          | Domain or IP address of the URL.                                                                                                                                                                    |
-| `password` | `Resolved<string>`         |          | A password to be specified before the hostname.                                                                                                                                                     |
-| `pathname` | `Resolved<string>`         |          | Slash-delimited path from the root of the host to a resource.                                                                                                                                       |
-| `port`     | `Resolved<string>`         |          | Port number of the URL.                                                                                                                                                                             |
-| `protocol` | `Resolved<string>`         | `https:` | Protocol scheme of the URL, including the final `:`.                                                                                                                                                |
-| `query`    | `Resolved<object<string>>` |          | Object to encode into a query string. Keys are query parameter names, and values must resolve to primitives (strings, numbers, booleans, etc) that will be URL-encoded into query parameter values. |
-| `search`   | `Resolved<string>`         |          | Serialized query string. Values must be URL (percent) encoded.                                                                                                                                      |
+| Property   | Type                        | Default  | Description                                                                                                                                                                                         |
+| ---------- | --------------------------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `baseUrl`  | `Resolved<string\|boolean>` |          | _Required_. The base URL to use for constructing the new URL. Must be `false` if no base URL is required.                                                                                           |
+| `hash`     | `Resolved<string>`          |          | Hash fragment of the URL, beginning with `#`.                                                                                                                                                       |
+| `hostname` | `Resolved<string>`          |          | Domain or IP address of the URL.                                                                                                                                                                    |
+| `password` | `Resolved<string>`          |          | A password to be specified before the hostname.                                                                                                                                                     |
+| `pathname` | `Resolved<string>`          |          | Slash-delimited path from the root of the host to a resource.                                                                                                                                       |
+| `port`     | `Resolved<string>`          |          | Port number of the URL.                                                                                                                                                                             |
+| `protocol` | `Resolved<string>`          | `https:` | Protocol scheme of the URL, including the final `:`.                                                                                                                                                |
+| `query`    | `Resolved<object<string>>`  |          | Object to encode into a query string. Keys are query parameter names, and values must resolve to primitives (strings, numbers, booleans, etc) that will be URL-encoded into query parameter values. |
+| `search`   | `Resolved<string>`          |          | Serialized query string. Values must be URL (percent) encoded.                                                                                                                                      |
 
 #### UrlResolver Notes
 

--- a/packages/upward-spec/README.md
+++ b/packages/upward-spec/README.md
@@ -214,14 +214,14 @@ When an UPWARD-compliant server receives an HTTP GET request, it must populate a
 
   - `url`: A subset of a [URL record][url spec] as specified by WHATWG. The following properties should at least be populated; the Host header can be used to infer the origin.
 
-    | Attribute | Example
-    | --------- | -------
-    | `host`    | `example.com:8080`
-    | `hostname`| `example.com`
-    | `port`    | `8080`
-    | `pathname`| `/deep/blue/sea`
-    | `search`  | `?baby=beluga`
-    | `query`   | `{ "baby": "beluga" }`
+    | Attribute  | Example                |
+    | ---------- | ---------------------- |
+    | `host`     | `example.com:8080`     |
+    | `hostname` | `example.com`          |
+    | `port`     | `8080`                 |
+    | `pathname` | `/deep/blue/sea`       |
+    | `search`   | `?baby=beluga`         |
+    | `query`    | `{ "baby": "beluga" }` |
 
     Because HTTP servers are sometimes unable to ascertain their own domain names or origins, it is acceptable for one or more of the `href`, `origin`, `protocol`, `username`, `password`, `host`, `hostname`, and `port` properties to be undefined. However, a compliant server MUST provide `pathname`, `search`, and `query`.
 
@@ -524,9 +524,9 @@ The `inline` of an InlineResolver may be of any type; it may be a primitive valu
 
 #### InlineResolver Configuration Options
 
-| Property | Type | Default | Description
-| -------- | ---- | ------- | ---------------------------------------------
-| `inline`    | `any`|         | _Required._ The value to be assigned to context.
+| Property | Type  | Default | Description                                      |
+| -------- | ----- | ------- | ------------------------------------------------ |
+| `inline` | `any` |         | _Required._ The value to be assigned to context. |
 
 ### FileResolver
 
@@ -547,11 +547,11 @@ The above expression loads the content of the file `./productDetail.graphql` and
 
 #### FileResolver Configuration Options
 
-| Property | Type       | Default | Description
-| -------- | ---------- | ------- | ---------------------------------------------
-| `file`     | `Resolved<string>` |         | _Required_. Path to the file to be read. Resolved relative to the definition file.
-| `encoding`  | `Resolved<string>` | `utf-8` | Character set to use when reading the file as text. Can be `utf-8`, `latin-1`, or `binary`.
-| `parse`    | `Resolved<string>` | `auto`  | Attempt to parse the file as a given file type. The default of `auto` should attempt to determine the file type from its extension. The value `text` will effectively disable parsing. 
+| Property   | Type               | Default | Description                                                                                                                                                                            |
+| ---------- | ------------------ | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `file`     | `Resolved<string>` |         | _Required_. Path to the file to be read. Resolved relative to the definition file.                                                                                                     |
+| `encoding` | `Resolved<string>` | `utf-8` | Character set to use when reading the file as text. Can be `utf-8`, `latin-1`, or `binary`.                                                                                            |
+| `parse`    | `Resolved<string>` | `auto`  | Attempt to parse the file as a given file type. The default of `auto` should attempt to determine the file type from its extension. The value `text` will effectively disable parsing. |
 
 #### Parsing
 
@@ -605,7 +605,7 @@ An UPWARD server uses a `ServiceResolver` to obtain live data from a GraphQL bac
 ```yaml
 documentResult:
   resolver: service
-  url:
+  endpoint:
     resolver: url
     baseUrl:
       inline: https://example.com
@@ -648,13 +648,14 @@ documentResult:
 
 #### ServiceResolver Configuration Options
 
-| Property  | Type               | Default                     | Description
-| --------- | ------------------ | --------------------------- | ---------------
-| `url`       | `Resolved<string>` | `https://localhost/graphql` | _Required_. The URL of the service endpoint to call.
-| `method`    | `Resolved<string>` | `POST`                      | The HTTP method to use. While GraphQL queries are typically POSTS, some services expose GraphQL over GET instead.
-| `headers`   | `Resolved<Object<string,string>>` |              | Additional HTTP headers to send with the GraphQL request. Some headers are set automatically, but the `headers` configuration can append to headers that can have multiple values.
-| `query`     | `Resolved<Query|string>` |                       | _Required_. The GraphQL query object. Can either be a parsed query, or a string that can be parsed as a valid query.
-| `variables` | `Resolved<Object<any>>` | `{}`            | Variables to use with the GraphQL query. Must resolve to an object with keys and values, almost always with an InlineResolver.
+| Property    | Type                              | Default                     | Description                                                                                                                                                                                                                              |
+| ----------- | --------------------------------- | --------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `endpoint`  | `Resolved<string>`                | `https://localhost/graphql` | _Required_. The URL of the service endpoint to call.                                                                                                                                                                                     |
+| `url`       | `Resolved<string>`                | `https://localhost/graphql` | :no_entry_sign: _**Deprecated**_. Synonymous with `endpoint`. Replaced with `endpoint` for readability. This parameter is still supported for now, but should be replaced with `endpoint`. If both are present, an error will be thrown. |
+| `method`    | `Resolved<string>`                | `POST`                      | The HTTP method to use. While GraphQL queries are typically POSTS, some services expose GraphQL over GET instead.                                                                                                                        |
+| `headers`   | `Resolved<Object<string,string>>` |                             | Additional HTTP headers to send with the GraphQL request. Some headers are set automatically, but the `headers` configuration can append to headers that can have multiple values.                                                       |
+| `query`     | `Resolved<Query|string>`          |                             | _Required_. The GraphQL query object. Can either be a parsed query, or a string that can be parsed as a valid query.                                                                                                                     |
+| `variables` | `Resolved<Object<any>>`           | `{}`                        | Variables to use with the GraphQL query. Must resolve to an object with keys and values, almost always with an InlineResolver.                                                                                                           |
 
 **ServiceResolvers always use GraphQL.** To obtain data from a non-GraphQL service, an UPWARD server may implement client-side directives which change the behavior of a GraphQL query, such as [apollo-link-rest][apollo-link-rest], and place the directives in the query itself. This should be transparent to the UPWARD server itself, which delegates the service call to a GraphQL client. If an UPWARD server's GraphQL client has no implementation for such a directive, then it must pass the query unmodified to the backing service to handle the directive.
 
@@ -743,11 +744,11 @@ The above configuration resolves into an HTML document displaying content from t
 
 #### TemplateResolver Configuration Options
 
-| Property  | Type               | Default                     | Description
-| --------- | ------------------ | --------------------------- | ---------------
-| `engine`    | `Resolved<string>` |                             | _Required_. The label of the template engine to use.
-| `provide`      | `Resolved<string[]|object<string>>`    |                  | _Required._ A list, or an object mapping, of values to make available in the template. Passing the entire context to a template for evaluation can cause cyclic dependencies.
-| `template`   | `Resolved<Template|string>` |              | The template to render.
+| Property   | Type                                | Default | Description                                                                                                                                                                   |
+| ---------- | ----------------------------------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `engine`   | `Resolved<string>`                  |         | _Required_. The label of the template engine to use.                                                                                                                          |
+| `provide`  | `Resolved<string[]|object<string>>` |         | _Required._ A list, or an object mapping, of values to make available in the template. Passing the entire context to a template for evaluation can cause cyclic dependencies. |
+| `template` | `Resolved<Template|string>`         |         | The template to render.                                                                                                                                                       |
 
 #### Template Context
 
@@ -904,20 +905,20 @@ If some other configuration provides a different `status`, such as `200`, then n
 
 #### ConditionalResolver Configuration Options
 
-| Property  | Type               | Default     | Description
-| --------- | ------------------ | ----------- | ---------------
-| `when`    | `Matcher[]` |      |             | _Required_. The list of matchers to test against context.
-| `default` | `Resolved<any>`    |             | _Required_. The default resolver to use if no matcher succeeds.
+| Property  | Type            | Default | Description                                                     |
+| --------- | --------------- | ------- | --------------------------------------------------------------- |
+| `when`    | `Matcher[]`     |         |                                                                 | _Required_. The list of matchers to test against context. |
+| `default` | `Resolved<any>` |         | _Required_. The default resolver to use if no matcher succeeds. |
 
 #### Matchers
 
 A `Matcher` is an object which can only be used as an item in a ConditionalResolver's `when` list. It must have the following properties:
 
-| Property  | Type               | Default | Description
-| --------- | ------------------ | ------- | ---------------
-| `matches` | `string`           |         | _Required_. The context value to match. Must be a bare string context lookup.
-| `pattern` | `string`           |         | _Required_. [PCRE][pcre] regular expression to use to test against the value in `matches`.
-| `use`     | `Resolved<any>`    |         | _Required_. Resolver to use if the match succeeds.
+| Property  | Type            | Default | Description                                                                                |
+| --------- | --------------- | ------- | ------------------------------------------------------------------------------------------ |
+| `matches` | `string`        |         | _Required_. The context value to match. Must be a bare string context lookup.              |
+| `pattern` | `string`        |         | _Required_. [PCRE][pcre] regular expression to use to test against the value in `matches`. |
+| `use`     | `Resolved<any>` |         | _Required_. Resolver to use if the match succeeds.                                         |
 
 #### Match context
 
@@ -958,10 +959,10 @@ proxy:
 
 #### ProxyResolver Configuration Options
 
-| Property  | Type               | Default     | Description
-| --------- | ------------------ | ----------- | ---------------
-| `target`    | `Resolved<string>` |      |             | _Required_. The URL that receives proxied requess.
-| `ignoreSSLErrors` | `Resolved<boolean>`    | `false`            | Ignore remnote SSL certificate errors (useful for internal communication among containers).
+| Property          | Type                | Default | Description                                                                                 |
+| ----------------- | ------------------- | ------- | ------------------------------------------------------------------------------------------- |
+| `target`          | `Resolved<string>`  |         |                                                                                             | _Required_. The URL that receives proxied requess. |
+| `ignoreSSLErrors` | `Resolved<boolean>` | `false` | Ignore remnote SSL certificate errors (useful for internal communication among containers). |
 
 #### ProxyResolver notes
 
@@ -982,9 +983,9 @@ static:
 
 #### DirectoryResolver Configuration Options
 
-| Property    | Type               | Default     | Description
-| ----------- | ------------------ | ----------- | ---------------
-| `directory` | `Resolved<string>` |             | _Required_. The local directory path to be served.
+| Property    | Type               | Default | Description                                        |
+| ----------- | ------------------ | ------- | -------------------------------------------------- |
+| `directory` | `Resolved<string>` |         | _Required_. The local directory path to be served. |
 
 ### UrlResolver
 
@@ -1036,17 +1037,17 @@ https://admin.host:8081/api/rest/v1/adminToken?refreshToken=a1b2c3&role=owner
 
 #### UrlResolver Configuration Options
 
-| Property   | Type                       | Default     | Description
-| ---------- | -------------------------- | ----------- | ---------------
-| `baseUrl`  | `Resolved<string|boolean>` |             | _Required_. The base URL to use for constructing the new URL. Must be `false` if no base URL is required.
-| `hash`     | `Resolved<string>`         |             | Hash fragment of the URL, beginning with `#`.
-| `hostname` | `Resolved<string>`         |             | Domain or IP address of the URL.
-| `password` | `Resolved<string>`         |             | A password to be specified before the hostname.
-| `pathname` | `Resolved<string>`         |             | Slash-delimited path from the root of the host to a resource.
-| `port`     | `Resolved<string>`         |             | Port number of the URL.
-| `protocol` | `Resolved<string>`         | `https:`    | Protocol scheme of the URL, including the final `:`.
-| `query`    | `Resolved<object<string>>` |             | Object to encode into a query string. Keys are query parameter names, and values must resolve to primitives (strings, numbers, booleans, etc) that will be URL-encoded into query parameter values.
-| `search`   | `Resolved<string>`         |             | Serialized query string. Values must be URL (percent) encoded.
+| Property   | Type                       | Default  | Description                                                                                                                                                                                         |
+| ---------- | -------------------------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `baseUrl`  | `Resolved<string|boolean>` |          | _Required_. The base URL to use for constructing the new URL. Must be `false` if no base URL is required.                                                                                           |
+| `hash`     | `Resolved<string>`         |          | Hash fragment of the URL, beginning with `#`.                                                                                                                                                       |
+| `hostname` | `Resolved<string>`         |          | Domain or IP address of the URL.                                                                                                                                                                    |
+| `password` | `Resolved<string>`         |          | A password to be specified before the hostname.                                                                                                                                                     |
+| `pathname` | `Resolved<string>`         |          | Slash-delimited path from the root of the host to a resource.                                                                                                                                       |
+| `port`     | `Resolved<string>`         |          | Port number of the URL.                                                                                                                                                                             |
+| `protocol` | `Resolved<string>`         | `https:` | Protocol scheme of the URL, including the final `:`.                                                                                                                                                |
+| `query`    | `Resolved<object<string>>` |          | Object to encode into a query string. Keys are query parameter names, and values must resolve to primitives (strings, numbers, booleans, etc) that will be URL-encoded into query parameter values. |
+| `search`   | `Resolved<string>`         |          | Serialized query string. Values must be URL (percent) encoded.                                                                                                                                      |
 
 #### UrlResolver Notes
 
@@ -1164,15 +1165,15 @@ body:
 
 For any value which must be a Resolver or a context lookup, an UPWARD-compatible server should attempt to infer resolver types from a supplied resolver configuration object, rather than requiring a `resolver` name to be specified. Each resolver has required parameters that are mutually exclusive with one another, so a resolver type can be inferred from the presence of those parameters.
 
-| If parameter exists... | Then infer resolver type:
-| ---------------------: | :-----------------------:
-| `inline` | `InlineResolver`
-| `file` | `FileResolver`
-| `query` | `ServiceResolver`
-| `engine` | `TemplateResolver`
-| `when` | `ConditionalResolver`
-| `target` | `ProxyResolver`
-| `directory` | `DirectoryResolver`
+| If parameter exists... | Then infer resolver type: |
+| ---------------------: | :-----------------------: |
+|               `inline` |     `InlineResolver`      |
+|                 `file` |      `FileResolver`       |
+|                `query` |     `ServiceResolver`     |
+|               `engine` |    `TemplateResolver`     |
+|                 `when` |   `ConditionalResolver`   |
+|               `target` |      `ProxyResolver`      |
+|            `directory` |    `DirectoryResolver`    |
 
 Resolver type inference allows configuration to omit `resolver:` parameters, which makes it possible to be far more terse. The example optimized configuration in [Builtin constants](#builtin-constants) could be further reduced:
 

--- a/packages/upward-spec/suite/assertOnResponse.js
+++ b/packages/upward-spec/suite/assertOnResponse.js
@@ -44,13 +44,23 @@ module.exports = async (t, response, expected) => {
     });
     try {
         const body = await response.clone().text();
-        if (expected.text) {
-            const msg = `body should match '${expected.text}': ${body}`;
-            if (body.includes(expected.text)) {
-                t.pass(msg);
+        if (expected.contains) {
+            if (body.includes(expected.contains)) {
+                t.pass(`body should contain '${expected.contains}': ${body}`);
             } else {
-                t.fail(msg);
+                t.equals(
+                    expected.contains + body,
+                    body,
+                    `body should contain ${expected.contains}`
+                );
             }
+        }
+        if (expected.text) {
+            t.equals(
+                expected.text.trim(),
+                body.trim(),
+                `body should match text ${expected.text.trim()}`
+            );
         }
         if (expected.json) {
             let parsed;

--- a/packages/upward-spec/suite/runServer.js
+++ b/packages/upward-spec/suite/runServer.js
@@ -31,6 +31,7 @@ module.exports = async function runServer(
             const flags = {
                 crashed: false,
                 launched: false,
+                responding: false,
                 running: false
             };
             let stderr = '';
@@ -89,17 +90,7 @@ module.exports = async function runServer(
             function emitServer() {
                 clearTimeout(terminator);
                 resolve({
-                    stderr,
                     url,
-                    hasCrashed() {
-                        return flags.crashed;
-                    },
-                    hasLaunched() {
-                        return flags.launched;
-                    },
-                    isRunning() {
-                        return flags.running;
-                    },
                     async close() {
                         if (flags.running) {
                             return terminateClean().catch(e => test.error(e));
@@ -116,10 +107,7 @@ module.exports = async function runServer(
                             message += `, listening at ${url}`;
                         }
                         if (stderr) {
-                            message += `, emitting stderr ${stderr.slice(
-                                0,
-                                50
-                            )}[...]`;
+                            message += `, emitting stderr ${stderr}`;
                         }
                         const status =
                             flags[flag] === expected ? 'pass' : 'fail';

--- a/packages/upward-spec/suite/scenarios/003-request-handling/tests.js
+++ b/packages/upward-spec/suite/scenarios/003-request-handling/tests.js
@@ -23,7 +23,7 @@ tape.test('Reflect request', async t => {
             headers: {
                 'content-type': 'text/plain'
             },
-            text: 'some/path'
+            contains: 'some/path'
         });
 
         server.assert('crashed', false);

--- a/packages/upward-spec/suite/scenarios/004-resolvers/tests.js
+++ b/packages/upward-spec/suite/scenarios/004-resolvers/tests.js
@@ -1,0 +1,174 @@
+const { URL } = require('url');
+const fetch = require('node-fetch');
+const tape = require('tape');
+
+const { getScenarios, runServer, assertOnResponse } = require('../../');
+
+const gettingScenarios = getScenarios(/\d+-resolvers/);
+
+tape.test('URLResolver extends base URLs producing absolute URLs', async t => {
+    const scenarios = await gettingScenarios;
+    const server = await runServer(
+        t,
+        scenarios.getResourcePath('./url-resolver-absolute.yml')
+    );
+
+    if (server.assert('launched')) {
+        try {
+            const response = await fetch(new URL('/?id=2', server.url), {
+                timeout: process.env.TAP_TIMEOUT || 5000
+            });
+            await assertOnResponse(t, response, {
+                status: 200,
+                headers: {
+                    'content-type': 'text/plain'
+                },
+                text: 'https://user:pass@example.com:3000/document/2'
+            });
+        } catch (e) {
+            server.assert('responding', true);
+        }
+        server.assert('running', true);
+    }
+
+    await server.close();
+    t.end();
+});
+
+tape.test('URLResolver allows protocol override', async t => {
+    const scenarios = await gettingScenarios;
+    const server = await runServer(
+        t,
+        scenarios.getResourcePath('./url-resolver-absolute-unsecure.yml')
+    );
+
+    const base = escape('https://example.com/scope');
+
+    if (server.assert('launched')) {
+        try {
+            const response = await fetch(
+                new URL('/?id=2&base=' + base, server.url),
+                {
+                    timeout: process.env.TAP_TIMEOUT || 5000
+                }
+            );
+            await assertOnResponse(t, response, {
+                status: 200,
+                headers: {
+                    'content-type': 'text/plain'
+                },
+                text: 'http://user:pass@example.com:3000/document/2'
+            });
+        } catch (e) {
+            server.assert('responding', true);
+        }
+        server.assert('running', true);
+    }
+
+    await server.close();
+    t.end();
+});
+
+tape.test(
+    'URLResolver extends base URLs respecting relative paths',
+    async t => {
+        const scenarios = await gettingScenarios;
+        const server = await runServer(
+            t,
+            scenarios.getResourcePath('./url-resolver-relative.yml')
+        );
+
+        if (server.assert('launched')) {
+            try {
+                const response = await fetch(new URL('/?id=3', server.url), {
+                    timeout: process.env.TAP_TIMEOUT || 5000
+                });
+                await assertOnResponse(t, response, {
+                    status: 200,
+                    headers: {
+                        'content-type': 'text/plain'
+                    },
+                    text: '/scope/document/3'
+                });
+            } catch (e) {
+                server.assert('responding', true);
+            }
+            server.assert('running', true);
+        }
+
+        await server.close();
+        t.end();
+    }
+);
+
+tape.test(
+    'URLResolver extends base URLs respecting slashes indicating root relative paths',
+    async t => {
+        const scenarios = await gettingScenarios;
+        const server = await runServer(
+            t,
+            scenarios.getResourcePath('./url-resolver-root-relative.yml')
+        );
+
+        if (server.assert('launched')) {
+            try {
+                const response = await fetch(new URL('/?id=3', server.url), {
+                    timeout: process.env.TAP_TIMEOUT || 5000
+                });
+                await assertOnResponse(t, response, {
+                    status: 200,
+                    headers: {
+                        'content-type': 'text/plain'
+                    },
+                    text: '/document/3?foo=baz&guh=wuh'
+                });
+            } catch (e) {
+                server.assert('responding', true);
+            }
+            server.assert('running', true);
+        }
+
+        await server.close();
+        t.end();
+    }
+);
+
+tape.test('URLResolver builds urls from templates', async t => {
+    const scenarios = await gettingScenarios;
+    const server = await runServer(
+        t,
+        scenarios.getResourcePath('./url-resolver-with-template.yml'),
+        {
+            ADMIN_REFRESH_TOKEN: 'a1b2c3',
+            ADMIN_PORT: 8081,
+            ADMIN_API_VERSION: 2
+        }
+    );
+
+    const base = 'https://admin.host/api/rest';
+
+    if (server.assert('launched')) {
+        try {
+            const response = await fetch(
+                new URL(`/?adminApiBase=${base}/`, server.url),
+                {
+                    timeout: process.env.TAP_TIMEOUT || 5000
+                }
+            );
+            await assertOnResponse(t, response, {
+                status: 200,
+                headers: {
+                    'content-type': 'text/plain'
+                },
+                text:
+                    'https://admin.host:8081/api/rest/v2/adminToken?refreshToken=a1b2c3&role=owner'
+            });
+        } catch (e) {
+            server.assert('responding', true);
+        }
+        server.assert('running', true);
+    }
+
+    await server.close();
+    t.end();
+});

--- a/packages/upward-spec/suite/scenarios/004-resolvers/url-resolver-absolute-unsecure.yml
+++ b/packages/upward-spec/suite/scenarios/004-resolvers/url-resolver-absolute-unsecure.yml
@@ -1,0 +1,25 @@
+status: 200
+headers:
+  inline:
+    content-type: text/plain
+body: rewrittenUrl
+
+rewrittenUrl:
+  baseUrl: documentBase
+  pathname: request.url.query.id
+
+documentBase:
+  baseUrl: rootUrl
+  pathname:
+    inline: document/
+
+rootUrl:
+  baseUrl: request.url.query.base
+  username:
+    inline: user
+  password:
+    inline: pass
+  protocol:
+    inline: 'http:'
+  port:
+    inline: 3000

--- a/packages/upward-spec/suite/scenarios/004-resolvers/url-resolver-absolute.yml
+++ b/packages/upward-spec/suite/scenarios/004-resolvers/url-resolver-absolute.yml
@@ -1,0 +1,25 @@
+status: 200
+headers:
+  inline:
+    content-type: text/plain
+body: rewrittenUrl
+
+rewrittenUrl:
+  baseUrl: documentBase
+  pathname: request.url.query.id
+
+documentBase:
+  baseUrl: rootUrl
+  pathname:
+    inline: /document/
+
+rootUrl:
+  baseUrl: false
+  hostname:
+    inline: example.com
+  username:
+    inline: user
+  password:
+    inline: pass
+  port:
+    inline: 3000

--- a/packages/upward-spec/suite/scenarios/004-resolvers/url-resolver-relative.yml
+++ b/packages/upward-spec/suite/scenarios/004-resolvers/url-resolver-relative.yml
@@ -1,0 +1,19 @@
+status: 200
+headers:
+  inline:
+    content-type: text/plain
+body: rewrittenUrl
+
+rewrittenUrl:
+  baseUrl: documentBase
+  pathname: request.url.query.id
+
+documentBase:
+  baseUrl: rootUrl
+  pathname:
+    inline: document/
+
+rootUrl:
+  baseUrl: false
+  pathname:
+    inline: scope/

--- a/packages/upward-spec/suite/scenarios/004-resolvers/url-resolver-root-relative.yml
+++ b/packages/upward-spec/suite/scenarios/004-resolvers/url-resolver-root-relative.yml
@@ -1,0 +1,31 @@
+status: 200
+headers:
+  inline:
+    content-type: text/plain
+body: rewrittenUrl
+
+rewrittenUrl:
+  baseUrl: documentBase
+  pathname: request.url.query.id
+
+documentBase:
+  baseUrl: rootUrl
+  pathname:
+    inline: /document/
+  query: additionalParams
+
+rootUrl:
+  baseUrl: false
+  pathname:
+    inline: scope/
+  query:
+    inline:
+      foo:
+        inline: bar
+
+additionalParams:
+  inline:
+    foo:
+      inline: baz
+    guh:
+      inline: wuh

--- a/packages/upward-spec/suite/scenarios/004-resolvers/url-resolver-with-template.yml
+++ b/packages/upward-spec/suite/scenarios/004-resolvers/url-resolver-with-template.yml
@@ -1,0 +1,27 @@
+status: 200
+headers:
+  inline:
+    content-type: text/plain
+body: adminRESTTokenRefresh
+
+adminRESTTokenRefresh:
+  baseUrl: adminRESTApiBase
+  pathname:
+    inline: adminToken
+  query:
+    inline:
+      refreshToken: env.ADMIN_REFRESH_TOKEN
+      role:
+        inline: owner
+
+adminRESTApiBase:
+  baseUrl: request.url.query.adminApiBase
+  port: env.ADMIN_PORT
+  pathname: apiVersion
+
+apiVersion:
+  engine: mustache
+  provide:
+    versionNumber: env.ADMIN_API_VERSION
+  template:
+    inline: 'v{{versionNumber}}/'

--- a/packages/venia-concept/venia-upward.yml
+++ b/packages/venia-concept/venia-upward.yml
@@ -46,14 +46,18 @@ imageOpt:
     headers:
       inline:
         Location:
-          baseUrl: request.url.query.url
-          query:
-            inline:
-              auto:
-                inline: webp
-              format:
-                inline: pjpg
-              width: $match.$1
+          engine: mustache
+          provide:
+            width: $match.$1
+            path: request.url.query.url
+          template:
+            when:
+              - matches: env.USE_FASTLY
+                pattern: '[^0]'
+                use:
+                  inline: '{{path}}?auto=webp&format=pjpg&width={{width}}'
+            default:
+              inline: '{{path}}'
 
 isDevelopment:
   when:
@@ -148,9 +152,11 @@ urlResolverResult:
       urlKey: request.url.pathname
 
 magentoGQL:
-  baseUrl: env.MAGENTO_BACKEND_URL
-  pathname:
-    inline: graphql
+  engine: mustache
+  template:
+    inline: '{{env.MAGENTO_BACKEND_URL}}/graphql'
+  provide:
+    - env
 
 product: productResult.data.productDetail.items.0
 productResult:

--- a/packages/venia-concept/venia-upward.yml
+++ b/packages/venia-concept/venia-upward.yml
@@ -46,18 +46,14 @@ imageOpt:
     headers:
       inline:
         Location:
-          engine: mustache
-          provide:
-            width: $match.$1
-            path: request.url.query.url
-          template:
-            when:
-              - matches: env.USE_FASTLY
-                pattern: '[^0]'
-                use:
-                  inline: '{{path}}?auto=webp&format=pjpg&width={{width}}'
-            default:
-              inline: '{{path}}'
+          baseUrl: request.url.query.url
+          query:
+            inline:
+              auto:
+                inline: webp
+              format:
+                inline: pjpg
+              width: $match.$1
 
 isDevelopment:
   when:
@@ -152,11 +148,9 @@ urlResolverResult:
       urlKey: request.url.pathname
 
 magentoGQL:
-  engine: mustache
-  template:
-    inline: '{{env.MAGENTO_BACKEND_URL}}/graphql'
-  provide:
-    - env
+  baseUrl: env.MAGENTO_BACKEND_URL
+  pathname:
+    inline: graphql
 
 product: productResult.data.productDetail.items.0
 productResult:


### PR DESCRIPTION
<!--
Thank you for your contribution!

Before submitting this pull request, please make sure you have read our Contribution Guidelines and your PR meets our contribution standards:
https://github.com/magento-research/pwa-studio/blob/master/.github/CONTRIBUTING.md

Please fill out as much information as you can about your PR to help speed up the review process.
If your PR addresses an existing GitHub Issue, please refer to it in the title or Additional Information section to make the connection.

We may ask you for changes in your PR in order to meet the standards set in our Contribution Guidelines. PRs that do not comply with our guidelines may be closed at the maintainers' discretion.

Feel free to remove this section before creating this PR.
-->

<!--- Provide a general summary of your changes in the Title above -->

## Description
Add an eighth Resolver to UPWARD, the **UrlResolver**.

- Add the resolver to upward-js, along with unit tests.
- Add tests for the UrlResolver to `upward-spec`, the cross-platform test suite.
- Add documentation to the README for UPWARD.
- Modify venia-upward.yml to use the UrlResolver instead of TempateResolvers to join URLs.

## Related Issue
Closes #1057.
Related to #1045 and other issues resolving URLs for ServiceResolvers or ProxyResolvers..

## Motivation and Context
See #1057; URLs should be a first class concept in UPWARD.


## Verification
Experiment with URL resolution based on the documentation. Try different configurations in Venia.


## How Has This Been Tested?
Full test coverage and integration test suite coverage.
Tried all cases in Venia where UPWARD resolves URLs. This resolver simplifies the Venia UPWARD definition and makes it more reliable.


## Proposed Labels for Change Type/Package
<!--- What types of changes does your code introduce? Let us know if this is a -->
FEATURE in upward-js
ENHANCEMENT in venia-concept

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have linked an issue to this PR.
- [x] I have indicated the change type and relevant package(s).
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] All CI checks are green (linting, build/deploy, etc).
- [ ] At least one core contributor has approved this PR.
