### PR TITLE
bug: use placeholder in carousel while loading next image

### DIFF
--- a/packages/venia-concept/src/components/ProductImageCarousel/__tests__/__snapshots__/carousel.spec.js.snap
+++ b/packages/venia-concept/src/components/ProductImageCarousel/__tests__/__snapshots__/carousel.spec.js.snap
@@ -34,6 +34,12 @@ exports[`renders a transparent main image if no file name is provided 1`] = `
     <img
       alt="image-product"
       className="currentImage"
+      onLoad={[Function]}
+      src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAQAAAAFCAQAAADIpIVQAAAADklEQVR42mNkgAJGIhgAALQABsHyMOcAAAAASUVORK5CYII="
+    />
+    <img
+      alt="image-product"
+      className="currentImage"
       src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAQAAAAFCAQAAADIpIVQAAAADklEQVR42mNkgAJGIhgAALQABsHyMOcAAAAASUVORK5CYII="
     />
     <button
@@ -101,7 +107,13 @@ exports[`renders the Carousel component correctly w/ sorted images 1`] = `
     <img
       alt="test-thumbnail1"
       className="currentImage"
+      onLoad={[Function]}
       src="/img/resize/640?url=%2Fmedia%2Fcatalog%2Fproduct%2Fthumbnail1.png"
+    />
+    <img
+      alt="test-thumbnail1"
+      className="currentImage"
+      src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAQAAAAFCAQAAADIpIVQAAAADklEQVR42mNkgAJGIhgAALQABsHyMOcAAAAASUVORK5CYII="
     />
     <button
       className="chevron-right"

--- a/packages/venia-concept/src/components/ProductImageCarousel/__tests__/carousel.spec.js
+++ b/packages/venia-concept/src/components/ProductImageCarousel/__tests__/carousel.spec.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import testRenderer from 'react-test-renderer';
-
+import { transparentPlaceholder } from 'src/shared/images';
 import Carousel from '../carousel';
 
 jest.mock('src/classify');
@@ -60,9 +60,9 @@ test('renders active item as main image', () => {
     const button = component.root.findByProps({ className: 'rootSelected' });
     const activeImageThumbnailAlt = button.children[0].props.alt;
 
-    const activeImage = component.root.findByProps({
+    const activeImage = component.root.findAllByProps({
         className: 'currentImage'
-    });
+    })[0];
     const activeImageAlt = activeImage.props.alt;
 
     expect(activeImageAlt).toEqual('test-thumbnail1');
@@ -80,9 +80,9 @@ test('updates main image when non-active item is clicked', () => {
     const button = component.root.findByProps({ className: 'rootSelected' });
     const activeImageThumbnailAlt = button.children[0].props.alt;
 
-    const activeImage = component.root.findByProps({
+    const activeImage = component.root.findAllByProps({
         className: 'currentImage'
-    });
+    })[0];
     const activeImageAlt = activeImage.props.alt;
 
     expect(activeImageAlt).toEqual('test-thumbnail2');
@@ -102,9 +102,9 @@ test('renders prior image when left chevron is clicked', () => {
     });
     leftButton.props.onClick();
 
-    const activeImage = component.root.findByProps({
+    const activeImage = component.root.findAllByProps({
         className: 'currentImage'
-    });
+    })[0];
     const activeImageAlt = activeImage.props.alt;
 
     expect(activeImageAlt).toEqual('test-thumbnail1');
@@ -118,9 +118,9 @@ test('renders last image when left chevron is clicked and first item is active',
     });
     leftButton.props.onClick();
 
-    const activeImage = component.root.findByProps({
+    const activeImage = component.root.findAllByProps({
         className: 'currentImage'
-    });
+    })[0];
     const activeImageAlt = activeImage.props.alt;
 
     expect(activeImageAlt).toEqual('test-thumbnail4');
@@ -134,9 +134,9 @@ test('renders next image when right chevron is clicked', () => {
     });
     leftButton.props.onClick();
 
-    const activeImage = component.root.findByProps({
+    const activeImage = component.root.findAllByProps({
         className: 'currentImage'
-    });
+    })[0];
     const activeImageAlt = activeImage.props.alt;
 
     expect(activeImageAlt).toEqual('test-thumbnail2');
@@ -155,9 +155,9 @@ test('renders first image when right chevron is clicked and last item is active'
     });
     leftButton.props.onClick();
 
-    const activeImage = component.root.findByProps({
+    const activeImage = component.root.findAllByProps({
         className: 'currentImage'
-    });
+    })[0];
     const activeImageAlt = activeImage.props.alt;
 
     expect(activeImageAlt).toEqual('test-thumbnail1');
@@ -171,10 +171,29 @@ test('renders a transparent main image if no file name is provided', () => {
 test('sets main image alt as "image-product" if no label is provided', () => {
     const component = testRenderer.create(<Carousel images={[]} />);
 
-    const activeImage = component.root.findByProps({
+    const activeImage = component.root.findAllByProps({
         className: 'currentImage'
-    });
+    })[0];
     const activeImageAlt = activeImage.props.alt;
 
     expect(activeImageAlt).toEqual('image-product');
+});
+
+test('renders a placeholder until image is loaded', () => {
+    const component = testRenderer.create(<Carousel {...defaultProps} />);
+
+    const placeholderImage = component.root.findAllByProps({
+        className: 'currentImage'
+    })[1];
+    const placeholderImageSrc = placeholderImage.props.src;
+
+    expect(placeholderImageSrc).toEqual(transparentPlaceholder);
+
+    component.root.children[0].instance.setCurrentImageLoaded();
+
+    const images = component.root.findAllByProps({
+        className: 'currentImage'
+    });
+
+    expect(images.length).toEqual(1);
 });

--- a/packages/venia-concept/src/components/ProductImageCarousel/carousel.js
+++ b/packages/venia-concept/src/components/ProductImageCarousel/carousel.js
@@ -36,7 +36,8 @@ class Carousel extends Component {
     };
 
     state = {
-        activeItemIndex: 0
+        activeItemIndex: 0,
+        currentImageLoaded: false
     };
 
     updateActiveItemIndex = index => {
@@ -87,6 +88,12 @@ class Carousel extends Component {
         </button>
     );
 
+    setCurrentImageLoaded = () => {
+        this.setState({
+            currentImageLoaded: true
+        });
+    }
+
     render() {
         const { classes } = this.props;
 
@@ -101,7 +108,8 @@ class Carousel extends Component {
             <div className={classes.root}>
                 <div className={classes.imageContainer}>
                     {this.getChevron('left')}
-                    <img className={classes.currentImage} src={src} alt={alt} />
+                    <img onLoad={this.setCurrentImageLoaded} className={classes.currentImage} src={src} alt={alt} />
+                    {!this.state.currentImageLoaded ? <img className={classes.currentImage} src={transparentPlaceholder} alt={alt} />: null}
                     {this.getChevron('right')}
                 </div>
                 <ThumbnailList

--- a/packages/venia-concept/src/components/ProductImageCarousel/carousel.js
+++ b/packages/venia-concept/src/components/ProductImageCarousel/carousel.js
@@ -92,7 +92,7 @@ class Carousel extends Component {
         this.setState({
             currentImageLoaded: true
         });
-    }
+    };
 
     render() {
         const { classes } = this.props;
@@ -108,8 +108,19 @@ class Carousel extends Component {
             <div className={classes.root}>
                 <div className={classes.imageContainer}>
                     {this.getChevron('left')}
-                    <img onLoad={this.setCurrentImageLoaded} className={classes.currentImage} src={src} alt={alt} />
-                    {!this.state.currentImageLoaded ? <img className={classes.currentImage} src={transparentPlaceholder} alt={alt} />: null}
+                    <img
+                        onLoad={this.setCurrentImageLoaded}
+                        className={classes.currentImage}
+                        src={src}
+                        alt={alt}
+                    />
+                    {!this.state.currentImageLoaded ? (
+                        <img
+                            className={classes.currentImage}
+                            src={transparentPlaceholder}
+                            alt={alt}
+                        />
+                    ) : null}
                     {this.getChevron('right')}
                 </div>
                 <ThumbnailList


### PR DESCRIPTION
## Description
The carousel just uses a simple `<img>` tag to load the images on the PDP. There is a moment that, depending on network speed, we jutter the page while loading a variant or new image. This PR handles that by adding an `onLoad` handler and some local state to the carousel class so that we render a placeholder while loading the image.

One thing I wasn't sure about was how the transparent placeholder we created in `shared/images.js` is styled or sized. It seems to render a few pixels larger than the actual image so there is still a _slight_ jutter while we draw. That being said, this PR makes it much less jarring.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here with the specific wording: "Closes #<issue>" -->
<!--- Using the above wording causes Github to automatically close the issue on merge. -->
Closes #1084.

## Verification Steps
<!-- Please describe in detail how a reviewer can verify your changes. -->
1. Go to a product page with variants.
2. Click on a variant or size, or click next.
3. The page should not jutter, and you should see a placeholder image in place of the carousel image while the next image loads.

## How Have YOU Tested this?

I did the above.

## Screenshots / Screen Captures (if appropriate):
My gif capture tool doesn't have a high enough fps to capture the jutter...:cry:

## Proposed Labels for Change Type/Package
<!--- What type of change level would you suggest for this PR? -->
<!--- Major, Minor, or Patch? -->
<!--- See https://magento-research.github.io/pwa-studio/technologies/versioning/ for help -->
- [ ] major (e.g x.0.0 - a breaking change)
- [ ] minor (e.g 0.x.0 - a backwards compatible addition)
- [x] patch (e.g 0.0.x - a bug fix)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly, if necessary.
- [x] I have added tests to cover my changes, if necessary.
