### PR TITLE
[dev]: Update eslint config version

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "watch:venia": "yarn workspace @magento/venia-concept run watch; cd - >/dev/null"
   },
   "devDependencies": {
-    "@magento/eslint-config": "~1.3.0",
+    "@magento/eslint-config": "~1.4.0",
     "babel-eslint": "~10.0.1",
     "babel-plugin-module-resolver": "~3.2.0",
     "chalk": "~2.4.2",

--- a/packages/peregrine/src/RestApi/Magento2/__tests__/M2ApiRequest.spec.js
+++ b/packages/peregrine/src/RestApi/Magento2/__tests__/M2ApiRequest.spec.js
@@ -14,7 +14,7 @@ function mockFetchReturned({
     mockFetch.mockImplementationOnce(
         (_, { signal }) =>
             new Promise((resolve, reject) => {
-                let body = json
+                const body = json
                     ? JSON.stringify(typeof json === 'function' ? json() : json)
                     : typeof text === 'function'
                     ? text()

--- a/packages/peregrine/src/util/intlPatches.js
+++ b/packages/peregrine/src/util/intlPatches.js
@@ -40,14 +40,16 @@ const IntlPatches = {
             symbol: currency
         };
         const { symbol, decimal, groupDelim } = format;
-        // eslint-disable-next-line prefer-const
+        const parts = [{ type: 'currency', value: symbol }];
+
         const [integer, fraction] = num
             .toFixed(maximumFractionDigits)
             .match(/\d+/g);
-        const parts = [{ type: 'currency', value: symbol }];
+
         if (useGrouping !== false) {
             const intParts = [];
             const firstGroupLength = integer.length % 3;
+            let integerSlice = integer;
             if (firstGroupLength > 0) {
                 intParts.push(
                     JSON.stringify({
@@ -55,10 +57,10 @@ const IntlPatches = {
                         value: integer.slice(0, firstGroupLength)
                     })
                 );
-                integer = integer.slice(firstGroupLength);
+                integerSlice = integer.slice(firstGroupLength);
             }
 
-            const groups = integer.match(/\d{3}/g);
+            const groups = integerSlice.match(/\d{3}/g);
 
             if (groups) {
                 intParts.push(

--- a/packages/peregrine/src/util/intlPatches.js
+++ b/packages/peregrine/src/util/intlPatches.js
@@ -40,7 +40,8 @@ const IntlPatches = {
             symbol: currency
         };
         const { symbol, decimal, groupDelim } = format;
-        let [integer, fraction] = num
+        // eslint-disable-next-line prefer-const
+        const [integer, fraction] = num
             .toFixed(maximumFractionDigits)
             .match(/\d+/g);
         const parts = [{ type: 'currency', value: symbol }];

--- a/packages/pwa-buildpack/src/Utilities/__tests__/configureHost.spec.js
+++ b/packages/pwa-buildpack/src/Utilities/__tests__/configureHost.spec.js
@@ -212,7 +212,7 @@ test('fails after a timeout if devcert never fulfills', async () => {
     const oldIsTTY = process.stdin.isTTY;
     process.stdin.isTTY = true;
     let resolveHangingPromise;
-    let promise = new Promise(resolve => (resolveHangingPromise = resolve));
+    const promise = new Promise(resolve => (resolveHangingPromise = resolve));
     devcert.certificateFor.mockReturnValueOnce(promise);
     const certPromise = configureHost({ subdomain: 'no-hurry' });
     jest.advanceTimersByTime(35000);

--- a/packages/upward-js/lib/resolvers/TemplateResolver.js
+++ b/packages/upward-js/lib/resolvers/TemplateResolver.js
@@ -63,15 +63,13 @@ module.exports = class TemplateResolver extends AbstractResolver {
             providePromise
         ];
 
-        // eslint-disable-next-line prefer-const
-        let [engine, template, rootEntries] = await Promise.all(toResolve);
+        const [engineName, template, rootEntries] = await Promise.all(
+            toResolve
+        );
         debug('template retrieved, "%s"', template);
         debug('rootEntries retrieved, %o', rootEntries.map(([name]) => name));
 
-        if (!engine) {
-            engine = 'mustache';
-        }
-
+        const engine = engineName || 'mustache';
         const Engine = Engines[engine];
 
         if (!Engine) {

--- a/packages/upward-js/lib/resolvers/TemplateResolver.js
+++ b/packages/upward-js/lib/resolvers/TemplateResolver.js
@@ -63,6 +63,7 @@ module.exports = class TemplateResolver extends AbstractResolver {
             providePromise
         ];
 
+        // eslint-disable-next-line prefer-const
         let [engine, template, rootEntries] = await Promise.all(toResolve);
         debug('template retrieved, "%s"', template);
         debug('rootEntries retrieved, %o', rootEntries.map(([name]) => name));

--- a/packages/venia-concept/src/actions/cart/__tests__/asyncActions.spec.js
+++ b/packages/venia-concept/src/actions/cart/__tests__/asyncActions.spec.js
@@ -660,7 +660,7 @@ test('removeItemFromCart resets the guest cart when removing the last item in th
     getState.mockImplementationOnce(() => ({
         cart: { guestCartId: 'CART', details: { items_count: 1 } }
     }));
-    let payload = { item: 'ITEM' };
+    const payload = { item: 'ITEM' };
 
     // removeItemFromCart() calls storage.removeItem() to clear the guestCartId
     // but only if there's 1 item left in the cart
@@ -732,7 +732,7 @@ test('getCartDetails thunk creates a guest cart if no ID is found', async () => 
 });
 
 test('getCartDetails thunk deletes an old cart id and recreates a guest cart if cart ID is expired', async () => {
-    let tempStorage = {};
+    const tempStorage = {};
     mockSetItem.mockImplementation((key, value) => {
         tempStorage[key] = value;
     });

--- a/packages/venia-concept/src/actions/user/asyncActions.js
+++ b/packages/venia-concept/src/actions/user/asyncActions.js
@@ -113,7 +113,7 @@ export const assignGuestCartToCustomer = () =>
 
         try {
             const storage = new BrowserPersistence();
-            let guestCartId = storage.getItem('guestCartId');
+            const guestCartId = storage.getItem('guestCartId');
             const payload = {
                 customerId: user.id,
                 storeId: user.store_id

--- a/packages/venia-concept/src/components/Header/cartTrigger.js
+++ b/packages/venia-concept/src/components/Header/cartTrigger.js
@@ -27,7 +27,7 @@ export class Trigger extends Component {
         } = this.props;
         const itemsQty = details.items_qty;
         const iconColor = 'rgb(var(--venia-text))';
-        let svgAttributes = {
+        const svgAttributes = {
             stroke: iconColor
         };
 

--- a/packages/venia-concept/src/components/Input/input.js
+++ b/packages/venia-concept/src/components/Input/input.js
@@ -60,7 +60,7 @@ class Input extends Component {
 
     get helpText() {
         const { helpVisible, classes, helpText, helpType } = this.props;
-        let helpTypeClass = `${classes.helpText} ${classes[helpType]}`;
+        const helpTypeClass = `${classes.helpText} ${classes[helpType]}`;
 
         return helpVisible ? (
             <div className={helpTypeClass}>{helpText}</div>

--- a/packages/venia-concept/src/components/MiniCart/__tests__/kebab.spec.js
+++ b/packages/venia-concept/src/components/MiniCart/__tests__/kebab.spec.js
@@ -50,7 +50,7 @@ test('renders with item data', () => {
 test('list is inactive when kebab is closed', () => {
     const wrapper = shallow(<Kebab classes={classes} isOpen={false} />).dive();
 
-    let menu = wrapper.find('ul');
+    const menu = wrapper.find('ul');
     expect(menu.hasClass(classes.dropdown)).toBe(true);
     expect(menu.hasClass(classes.dropdown_active)).toBe(false);
 });
@@ -59,6 +59,6 @@ test('list gains "active" class when kebab is open', () => {
     const wrapper = shallow(<Kebab classes={classes} />).dive();
     wrapper.setState({ isOpen: true });
 
-    let menu = wrapper.find('ul');
+    const menu = wrapper.find('ul');
     expect(menu.hasClass(classes.dropdown_active)).toBe(true);
 });

--- a/packages/venia-concept/src/components/MiniCart/__tests__/product.spec.js
+++ b/packages/venia-concept/src/components/MiniCart/__tests__/product.spec.js
@@ -28,7 +28,7 @@ const item = {
 test('passed functions are called from nested `Section` components', () => {
     const removeItemFromCart = jest.fn();
     const openOptionsDrawer = jest.fn();
-    let wrapper = shallow(
+    const wrapper = shallow(
         <Product
             classes={classes}
             item={item}

--- a/packages/venia-concept/src/components/PurchaseHistoryPage/PurchaseHistory/purchaseHistoryContainer.js
+++ b/packages/venia-concept/src/components/PurchaseHistoryPage/PurchaseHistory/purchaseHistoryContainer.js
@@ -3,14 +3,10 @@ import { transformItems } from 'src/selectors/purchaseHistory';
 import PurchaseHistory from './purchaseHistory';
 import actions, { getPurchaseHistory } from 'src/actions/purchaseHistory';
 
-const mapStateToProps = ({ purchaseHistory }) => {
-    let { isFetching, items } = purchaseHistory;
-
-    items = transformItems(items);
-
+const mapStateToProps = ({ purchaseHistory: { isFetching, items} }) => {
     return {
         isFetching,
-        items
+        items: transformItems(items)
     };
 };
 

--- a/packages/venia-concept/src/components/PurchaseHistoryPage/PurchaseHistory/purchaseHistoryContainer.js
+++ b/packages/venia-concept/src/components/PurchaseHistoryPage/PurchaseHistory/purchaseHistoryContainer.js
@@ -3,10 +3,14 @@ import { transformItems } from 'src/selectors/purchaseHistory';
 import PurchaseHistory from './purchaseHistory';
 import actions, { getPurchaseHistory } from 'src/actions/purchaseHistory';
 
-const mapStateToProps = ({ purchaseHistory: { isFetching, items } }) => {
+const mapStateToProps = ({ purchaseHistory }) => {
+    const { isFetching } = purchaseHistory;
+
+    const items = transformItems(purchaseHistory.items);
+
     return {
         isFetching,
-        items: transformItems(items)
+        items
     };
 };
 

--- a/packages/venia-concept/src/components/PurchaseHistoryPage/PurchaseHistory/purchaseHistoryContainer.js
+++ b/packages/venia-concept/src/components/PurchaseHistoryPage/PurchaseHistory/purchaseHistoryContainer.js
@@ -3,7 +3,7 @@ import { transformItems } from 'src/selectors/purchaseHistory';
 import PurchaseHistory from './purchaseHistory';
 import actions, { getPurchaseHistory } from 'src/actions/purchaseHistory';
 
-const mapStateToProps = ({ purchaseHistory: { isFetching, items} }) => {
+const mapStateToProps = ({ purchaseHistory: { isFetching, items } }) => {
     return {
         isFetching,
         items: transformItems(items)

--- a/packages/venia-concept/src/components/SignIn/__tests__/signIn.spec.js
+++ b/packages/venia-concept/src/components/SignIn/__tests__/signIn.spec.js
@@ -52,7 +52,7 @@ test('display error message if there is a `signInError`', () => {
         />
     ).dive();
 
-    let errorMessage = shallow(wrapper.instance().errorMessage);
+    const errorMessage = shallow(wrapper.instance().errorMessage);
     expect(errorMessage.html()).toContain(props.signInError.message);
 });
 

--- a/packages/venia-concept/src/reducers/checkout.js
+++ b/packages/venia-concept/src/reducers/checkout.js
@@ -28,7 +28,7 @@ const reducerMap = {
         const storedBillingAddress = storage.getItem('billing_address');
         const storedPaymentMethod = storage.getItem('paymentMethod');
         const storedShippingAddress = storage.getItem('shipping_address');
-        let storedShippingMethod = storage.getItem('shippingMethod');
+        const storedShippingMethod = storage.getItem('shippingMethod');
 
         return {
             ...state,

--- a/packages/venia-concept/src/util/__tests__/combineValidators.spec.js
+++ b/packages/venia-concept/src/util/__tests__/combineValidators.spec.js
@@ -41,7 +41,7 @@ describe('combine', () => {
     });
 
     test('test calling the single fail validator', () => {
-        let result = combine([isRequiredFail])();
+        const result = combine([isRequiredFail])();
 
         expect(isRequiredFail).toHaveBeenCalledTimes(1);
         expect(typeof result).toBe('string');
@@ -62,7 +62,7 @@ describe('combine', () => {
     });
 
     test('the first validator returned message, the second is never called', () => {
-        let result = combine([isRequiredFail, [hasLengthExactly, 4]])();
+        const result = combine([isRequiredFail, [hasLengthExactly, 4]])();
 
         expect(isRequiredFail).toHaveBeenCalledTimes(1);
         expect(hasLengthExactly).toHaveBeenCalledTimes(0);

--- a/packages/venia-concept/src/util/__tests__/initObserver.spec.js
+++ b/packages/venia-concept/src/util/__tests__/initObserver.spec.js
@@ -2,7 +2,7 @@ import initObserver from '../initObserver';
 
 // mock a simple observer-type generator
 function* arrayObserver() {
-    let array = [];
+    const array = [];
 
     array.push(yield);
     array.push(yield);

--- a/packages/venia-concept/src/util/combineValidators.js
+++ b/packages/venia-concept/src/util/combineValidators.js
@@ -46,7 +46,7 @@ export default callbacks => {
         let result = null;
 
         for (let i = 0; i < callbacks.length; i++) {
-            let callback = callbacks[i];
+            const callback = callbacks[i];
 
             if (
                 callback == null ||
@@ -58,7 +58,7 @@ export default callbacks => {
             }
 
             if (Array.isArray(callback)) {
-                let [extendedCallback, extendedParam] = callback;
+                const [extendedCallback, extendedParam] = callback;
 
                 if (typeof extendedCallback !== 'function') {
                     throw new Error(

--- a/yarn.lock
+++ b/yarn.lock
@@ -1915,10 +1915,10 @@
   dependencies:
     es-comments "^1.0.1"
 
-"@magento/eslint-config@~1.3.0":
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/@magento/eslint-config/-/eslint-config-1.3.0.tgz#12ec0052858e22af0a5270dff56c0035ff9a7a61"
-  integrity sha512-tJf5MGdUGKnl+mosIdmg5pqpolvy6WmwmKPWOXwzAJquLdN1sOjkEYfloCX4YB6oHDYYJkdxADJ15gvePPifRA==
+"@magento/eslint-config@~1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@magento/eslint-config/-/eslint-config-1.4.0.tgz#b19dfcafa98c2c11bfc7bfa23d3b0e8ddc7aae0a"
+  integrity sha512-UV6MGHKrEkPmCGIuVdGZZM4JjgMpoYXAhGgun9Jqv0GiLumocgzhATRgCk0ykBb50Ztt/XiN9kxZfZ9MU0cJoA==
 
 "@magento/express-sharp@~2.1.1-newdeps.1":
   version "2.1.1-newdeps.1"


### PR DESCRIPTION
This PR Updates our magento-eslint config dep to v1.4.0 which adds the `prefer-const` rule. This rule is fairly straightforward and you can see what it does in the code. That being said there were a few places it did not agree with (array destructuring) so I just ignored those lines.

