### PR TITLE
Removes ability to add configurable items to cart until options are chosen

### DIFF
--- a/packages/pwa-buildpack/src/WebpackTools/__tests__/__fixtures__/queries/getProductDetail.graphql
+++ b/packages/pwa-buildpack/src/WebpackTools/__tests__/__fixtures__/queries/getProductDetail.graphql
@@ -1,6 +1,7 @@
 query productDetail($urlKey: String, $onServer: Boolean!) {
     productDetail: products(filter: { url_key: { eq: $urlKey } }) {
         items {
+            __typename
             sku
             name
             price {

--- a/packages/pwa-buildpack/src/WebpackTools/__tests__/__snapshots__/PWADevServer.spec.js.snap
+++ b/packages/pwa-buildpack/src/WebpackTools/__tests__/__snapshots__/PWADevServer.spec.js.snap
@@ -17,6 +17,7 @@ Object {
       "query": "query productDetail($urlKey: String, $onServer: Boolean!) {
     productDetail: products(filter: { url_key: { eq: $urlKey } }) {
         items {
+            __typename
             sku
             name
             price {

--- a/packages/venia-concept/src/components/MiniCart/__tests__/productOptions.spec.js
+++ b/packages/venia-concept/src/components/MiniCart/__tests__/productOptions.spec.js
@@ -17,6 +17,7 @@ const cartItem = {
 };
 
 const configItem = {
+    __typename: 'ConfigurableProduct',
     configurable_options: [
         {
             attribute_code: 'size',

--- a/packages/venia-concept/src/components/MiniCart/cartOptions.js
+++ b/packages/venia-concept/src/components/MiniCart/cartOptions.js
@@ -9,6 +9,7 @@ import defaultClasses from './cartOptions.css';
 import Button from 'src/components/Button';
 import Quantity from 'src/components/ProductQuantity';
 import appendOptionsToPayload from 'src/util/appendOptionsToPayload';
+import isProductConfigurable from 'src/util/isProductConfigurable';
 
 // TODO: get real currencyCode for cartItem
 const currencyCode = 'USD';
@@ -36,6 +37,7 @@ class CartOptions extends Component {
             qty: number.isRequired
         }),
         configItem: shape({
+            __typename: string,
             configurable_options: array
         }),
         isUpdatingItem: bool,
@@ -69,11 +71,7 @@ class CartOptions extends Component {
     handleClick = async () => {
         const { updateCart, cartItem, configItem } = this.props;
         const { optionSelections, quantity } = this.state;
-        const { configurable_options } = configItem;
-        const isConfigurable = Array.isArray(configurable_options);
-        const productType = isConfigurable
-            ? 'ConfigurableProduct'
-            : 'SimpleProduct';
+        const productType = configItem.__typename;
 
         const payload = {
             item: configItem,
@@ -81,9 +79,11 @@ class CartOptions extends Component {
             quantity: quantity
         };
 
-        if (productType === 'ConfigurableProduct') {
+        if (isProductConfigurable(configItem)) {
+            console.log('appending options to payload');
             appendOptionsToPayload(payload, optionSelections);
         }
+
         updateCart(payload, cartItem.item_id);
     };
 
@@ -91,17 +91,16 @@ class CartOptions extends Component {
         const { fallback, handleSelectionChange, props } = this;
         const { classes, cartItem, configItem, isUpdatingItem } = props;
         const { name, price } = cartItem;
-        const { configurable_options } = configItem;
 
         const modalClass = isUpdatingItem
             ? classes.modal_active
             : classes.modal;
 
-        const options = Array.isArray(configurable_options) ? (
+        const options = isProductConfigurable(configItem) ? (
             <Suspense fallback={fallback}>
                 <section className={classes.options}>
                     <Options
-                        options={configurable_options}
+                        options={configItem.configurable_options}
                         onSelectionChange={handleSelectionChange}
                     />
                 </section>

--- a/packages/venia-concept/src/components/MiniCart/cartOptions.js
+++ b/packages/venia-concept/src/components/MiniCart/cartOptions.js
@@ -71,16 +71,14 @@ class CartOptions extends Component {
     handleClick = async () => {
         const { updateCart, cartItem, configItem } = this.props;
         const { optionSelections, quantity } = this.state;
-        const productType = configItem.__typename;
 
         const payload = {
             item: configItem,
-            productType,
+            productType: configItem.__typename,
             quantity: quantity
         };
 
         if (isProductConfigurable(configItem)) {
-            console.log('appending options to payload');
             appendOptionsToPayload(payload, optionSelections);
         }
 

--- a/packages/venia-concept/src/components/ProductFullDetail/ProductFullDetail.js
+++ b/packages/venia-concept/src/components/ProductFullDetail/ProductFullDetail.js
@@ -14,11 +14,9 @@ import RichText from 'src/components/RichText';
 import defaultClasses from './productFullDetail.css';
 import appendOptionsToPayload from 'src/util/appendOptionsToPayload';
 import findMatchingVariant from 'src/util/findMatchingProductVariant';
+import isProductConfigurable from 'src/util/isProductConfigurable';
 
 const Options = React.lazy(() => import('../ProductOptions'));
-
-const productIsConfigurable = product =>
-    Array.isArray(product.configurable_options);
 
 class ProductFullDetail extends Component {
     static propTypes = {
@@ -38,6 +36,7 @@ class ProductFullDetail extends Component {
             title: string
         }),
         product: shape({
+            __typename: string,
             id: number,
             sku: string.isRequired,
             price: shape({
@@ -66,7 +65,7 @@ class ProductFullDetail extends Component {
         const optionCodes = new Map(state.optionCodes);
 
         // if this is a simple product, do nothing
-        if (!productIsConfigurable(props.product)) {
+        if (!isProductConfigurable(props.product)) {
             return null;
         }
 
@@ -90,10 +89,7 @@ class ProductFullDetail extends Component {
         const { props, state } = this;
         const { optionSelections, quantity, optionCodes } = state;
         const { addToCart, product } = props;
-        const isConfigurable = productIsConfigurable(product);
-        const productType = isConfigurable
-            ? 'ConfigurableProduct'
-            : 'SimpleProduct';
+        const productType = product.__typename;
 
         const payload = {
             item: product,
@@ -101,7 +97,8 @@ class ProductFullDetail extends Component {
             quantity
         };
 
-        if (productType === 'ConfigurableProduct') {
+        if (isProductConfigurable(product)) {
+            console.log('appending options to payload');
             appendOptionsToPayload(payload, optionSelections, optionCodes);
         }
 
@@ -124,7 +121,7 @@ class ProductFullDetail extends Component {
     get productOptions() {
         const { fallback, handleSelectionChange, props } = this;
         const { configurable_options } = props.product;
-        const isConfigurable = productIsConfigurable(props.product);
+        const isConfigurable = isProductConfigurable(props.product);
 
         if (!isConfigurable) {
             return null;
@@ -146,7 +143,7 @@ class ProductFullDetail extends Component {
         const { optionCodes, optionSelections } = state;
         const { media_gallery_entries, variants } = product;
 
-        const isConfigurable = productIsConfigurable(product);
+        const isConfigurable = isProductConfigurable(product);
 
         if (
             !isConfigurable ||
@@ -172,7 +169,7 @@ class ProductFullDetail extends Component {
         const { product } = this.props;
 
         // Non-configurable products can't be missing options
-        if (!productIsConfigurable(product)) {
+        if (!isProductConfigurable(product)) {
             return false;
         }
 

--- a/packages/venia-concept/src/components/ProductFullDetail/ProductFullDetail.js
+++ b/packages/venia-concept/src/components/ProductFullDetail/ProductFullDetail.js
@@ -89,16 +89,14 @@ class ProductFullDetail extends Component {
         const { props, state } = this;
         const { optionSelections, quantity, optionCodes } = state;
         const { addToCart, product } = props;
-        const productType = product.__typename;
 
         const payload = {
             item: product,
-            productType,
+            productType: product.__typename,
             quantity
         };
 
         if (isProductConfigurable(product)) {
-            console.log('appending options to payload');
             appendOptionsToPayload(payload, optionSelections, optionCodes);
         }
 

--- a/packages/venia-concept/src/queries/getProductDetail.graphql
+++ b/packages/venia-concept/src/queries/getProductDetail.graphql
@@ -1,6 +1,7 @@
 query productDetail($urlKey: String, $onServer: Boolean!) {
     productDetail: products(filter: { url_key: { eq: $urlKey } }) {
         items {
+            __typename
             sku
             name
             price {

--- a/packages/venia-concept/src/queries/getProductDetailByName.graphql
+++ b/packages/venia-concept/src/queries/getProductDetailByName.graphql
@@ -1,6 +1,7 @@
 query productDetailByName($name: String, $onServer: Boolean!) {
     products(filter: { name: { eq: $name } }) {
         items {
+            __typename
             id
             sku
             name

--- a/packages/venia-concept/src/util/__tests__/isProductConfigurable.spec.js
+++ b/packages/venia-concept/src/util/__tests__/isProductConfigurable.spec.js
@@ -1,0 +1,21 @@
+import isProductConfigurable from '../isProductConfigurable';
+
+test('returns true for a configurable product', () => {
+    const product = {
+        __typename: 'ConfigurableProduct'
+    };
+
+    const result = isProductConfigurable(product);
+
+    expect(result).toBe(true);
+});
+
+test('returns false for a non-configurable product', () => {
+    const product = {
+        __typename: 'SimpleProduct'
+    };
+
+    const result = isProductConfigurable(product);
+
+    expect(result).toBe(false);
+});

--- a/packages/venia-concept/src/util/isProductConfigurable.js
+++ b/packages/venia-concept/src/util/isProductConfigurable.js
@@ -1,0 +1,4 @@
+const isProductConfigurable = product =>
+    product.__typename === 'ConfigurableProduct';
+
+export default isProductConfigurable;


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail here -->

This PR disables the "Add to Cart" button on configurable product description pages (PDPs) until all product options have been selected.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here with the specific wording: "Closes #<issue>" -->
<!--- Using the above wording causes Github to automatically close the issue on merge. -->
Closes #640 .

## Verification Steps
<!-- Please describe in detail how a reviewer can verify your changes. -->

### Configurable Products
1. Select a configurable product (ex: https://magento-venia-concept-cj55l.local.pwadev:8582/valeria-two-layer-tank.html).
1. See that the "Add to Cart" button remains disabled until you make selections for each product option (color, size, etc.).

### Non-Configurable Products
1. Select a non-configurable product (ex: https://magento-venia-concept-cj55l.local.pwadev:8582/augusta-necklace.html).
1. See that the "Add to Cart" button is always enabled. 

## How Have YOU Tested this?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I loaded up a configurable and non-configurable product, as described above.

`yarn test` passes.

## Screenshots / Screen Captures (if appropriate):

<img width="303" alt="Screen Shot 2019-04-01 at 2 24 05 PM" src="https://user-images.githubusercontent.com/13182778/55350653-9562a200-548a-11e9-9116-336484b3cfd8.png">

## Proposed Labels for Change Type/Package
<!--- What type of change level would you suggest for this PR? -->
<!--- Major, Minor, or Patch? -->
<!--- See https://magento-research.github.io/pwa-studio/technologies/versioning/ for help -->
- [ ] major (e.g x.0.0 - a breaking change)
- [ ] minor (e.g 0.x.0 - a backwards compatible addition)
- [x] patch (e.g 0.0.x - a bug fix)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly, if necessary.
- [x] I have added tests to cover my changes, if necessary.

## Further Details / Risks / Notes / Etc.

This is perhaps the simplest solution to this problem. Some other options would be:

### Client-side, per-field Validation

Other forms in the app (ex: Address Form) have the ability to perform client-side, per-field validation and show error messages inline on the form.

Unfortunately the PDP would need to be heavily refactored to allow for this, and a solution for the color swatches would need to be included as part of this (changing them to radio buttons instead of actual buttons).

**Why I didn't go this route**:
We would still want to stick to Venia's precedent and pattern of not enabling the "submit" button of the form until all required fields are filled out, and since there is no additional client-side validation on top of _this field was filled in_, the refactor seemed to be too much work for not enough payoff.

Edit: turns out this isn't much of a precedent or pattern. The checkout flow doesn't enable the submit button until billing, payment, and shipping are filled in but other forms have their submit buttons enabled and hooked up to client-side validation first.

### Capturing the Error in Redux

Currently our backstop reducer handles the error from the server that results from attempting to add a configurable item to your cart without specifying options.

Ideally, the `cart` reducer handles this itself and passes the error back up to the UI (via Redux and `mapStateToProps`) so that the UI can show a nice, in-context error message.
 
**Why I didn't go this route**:
By disabling the "Add to Cart" button until all options are selected, we sidestep this problem.

Because client-side validation can be circumvented, some consideration should be given to the question of "what happens if the call to the server is made some other way?", in which case the backstop reducer would still kick in and the original issue would persist.

But I don't think solving for this case is worth it: if someone intentionally sidesteps our UI to make a server call, they shouldn't expect a nice clean UI if it fails.