### PR TITLE
TODO: Remove export keyword from search bar component

### DIFF
--- a/packages/venia-concept/src/components/SearchBar/searchBar.js
+++ b/packages/venia-concept/src/components/SearchBar/searchBar.js
@@ -20,8 +20,7 @@ const initialValues = {
 const clearIcon = <Icon src={ClearIcon} size={18} />;
 const searchIcon = <Icon src={SearchIcon} size={18} />;
 
-// TODO: remove export here (update story and test)
-export class SearchBar extends Component {
+class SearchBar extends Component {
     static propTypes = {
         classes: shape({
             clearIcon: string,


### PR DESCRIPTION
<!--
Before submitting this pull request, please make sure you have read our Contribution Guidelines and your PR meets our contribution standards:
https://github.com/magento-research/pwa-studio/blob/master/.github/CONTRIBUTING.md

Please fill out as much information as you can about your PR to help speed up the review process.
If your PR addresses an existing GitHub Issue, please refer to it in the title or Additional Information section to make the connection.

We may ask you for changes in your PR in order to meet the standards set in our Contribution Guidelines. PRs that do not comply with our guidelines may be closed at the maintainers' discretion.

Feel free to remove this section before creating this PR. Thank you for your contribution!
-->

## Description
<!--- Describe your changes in detail here -->
I've checked and got one TODO task in search bar component. I've fixed it also check test & storybook. there is no need to change in test & story.

## Verification Steps
<!-- Please describe in detail how a reviewer can verify your changes. -->
1. Go to Venia front store.
2. Search keyword in Serach box.

## Proposed Labels for Change Type/Package
<!--- What type of change level would you suggest for this PR? -->
<!--- Major, Minor, or Patch? -->
<!--- See https://magento-research.github.io/pwa-studio/technologies/versioning/ for help -->
- [ ] major (e.g x.0.0 - a breaking change)
- [x] minor (e.g 0.x.0 - a backwards compatible addition)
- [ ] patch (e.g 0.0.x - a bug fix)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly, if necessary.
- [ ] I have added tests to cover my changes, if necessary.
