### PR TITLE
bug fixes to make aws pr-test build work same as cicrcle ci

### DIFF
--- a/.bin/pr-checks
+++ b/.bin/pr-checks
@@ -10,15 +10,14 @@ message () {
   echo "==========================================================================="
   echo ""
 }
-STATUS=0
 
 message "Installing dependencies with yarn..."
-yarn install --frozen-lockfile
+yarn install --frozen-lockfile || exit 1
 
 # production build - needed for some of the subsequent checks, like storybook
 message "Running production build..."
 cp ./docker/.env.docker.prod ./packages/venia-concept/.env
-yarn run build
+yarn run build || exit 1
 
 # jest tests - does not fail ci, failures are evaluated by danger check below
 message "Running unit tests with Jest..."
@@ -28,14 +27,11 @@ message "Running Coveralls..."
 yarn run coveralls
 
 message "Running Storybook..."
-yarn workspace @magento/venia-concept run storybook:build
+yarn workspace @magento/venia-concept run storybook:build || exit 1
 
 message "Running Bundlesize..."
 yarn run bundlesize
 
 # danger ci - eslint, prettier:validate, unit test evaluation, etc.
 message "Running Danger..."
-yarn run danger || STATUS=$?
-
-echo "Exit Status: $STATUS"
-exit $STATUS
+yarn run danger


### PR DESCRIPTION
How to test - Fail conditions - 
1. To test yarn install --frozen-lockfile || exit 1 
   Change "babel-eslint": "~10.0.1" to    "babel-eslint": "~15.0.1"   and git Push then observe aws log.

2. To test yarn run build || exit 1
   packages/venia-concept/src/components/SearchBar/__stories__/searchBar.js  make some compilation errors like remove (    and git Push then observe aws log

3. To test yarn workspace @magento/venia-concept run storybook:build || exit 1
 packages/venia-concept/src/components/SearchBar/__stories__/searchBar.js   change import { SearchBar } from '../searchBar';  to import { SearchBar } from '../searchBar/adjshsf';    and git Push then observe aws log

4. To test yarn run danger    packages/venia-concept/src/__tests__/example.spec.js  change     expect(true).toBe(true); to     expect(true).toBe(false);

Pass Condition - 
If there are no errors then "yarn run danger "  should exit with status code 0