### PR TITLE
[Doc] Doc linter improvements

### DIFF
--- a/pwa-devdocs/scripts/lint/index.js
+++ b/pwa-devdocs/scripts/lint/index.js
@@ -11,7 +11,14 @@ const config = {
 const filepath = process.argv[2];
 if (filepath) {
     const fullPath = path.join(__dirname, '..', '..', filepath);
-    lintFile(fullPath);
+
+    fs.stat(fullPath, (error, stats) => {
+        if (stats.isFile()) {
+            lintFile(fullPath);
+        } else if (stats.isDirectory()) {
+            lintDirectory(fullPath);
+        }
+    });
 } else {
     lintDirectory(config.basePath);
 }

--- a/pwa-devdocs/scripts/lint/index.js
+++ b/pwa-devdocs/scripts/lint/index.js
@@ -7,7 +7,7 @@ const config = {
     basePath: path.join(__dirname, '../../src')
 };
 
-// If a single file is specified, only run tests on that file
+// If a file or directory is specified, only run tests on that file or directory
 const filepath = process.argv[2];
 if (filepath) {
     const fullPath = path.join(__dirname, '..', '..', filepath);

--- a/pwa-devdocs/scripts/lint/index.js
+++ b/pwa-devdocs/scripts/lint/index.js
@@ -13,10 +13,18 @@ if (filepath) {
     const fullPath = path.join(__dirname, '..', '..', filepath);
 
     fs.stat(fullPath, (error, stats) => {
-        if (stats.isFile()) {
+        if (error) {
+            console.error(error);
+        } else if (stats.isFile()) {
             lintFile(fullPath);
         } else if (stats.isDirectory()) {
             lintDirectory(fullPath);
+        } else {
+            console.error(
+                'ERROR:',
+                filepath,
+                'is neither a file nor directory'
+            );
         }
     });
 } else {

--- a/pwa-devdocs/scripts/markdown-linter/linter.js
+++ b/pwa-devdocs/scripts/markdown-linter/linter.js
@@ -1,11 +1,13 @@
 const remark = require('remark');
 const styleGuide = require('./style-guide');
 const vfile = require('to-vfile');
+const jekyllLinkTokenizer = require('./tokenizers').jekyllLink
 
 const linter = filepath => {
     return vfile.read(filepath).then(vfile => {
         return remark()
             .use(styleGuide)
+            .use(jekyllLinkTokenizer)
             .process(vfile);
     });
 };

--- a/pwa-devdocs/scripts/markdown-linter/tokenizers/index.js
+++ b/pwa-devdocs/scripts/markdown-linter/tokenizers/index.js
@@ -1,0 +1,3 @@
+module.exports = {
+    jekyllLink: require('./jekyll-link')
+}

--- a/pwa-devdocs/scripts/markdown-linter/tokenizers/jekyll-link.js
+++ b/pwa-devdocs/scripts/markdown-linter/tokenizers/jekyll-link.js
@@ -1,0 +1,54 @@
+/**
+ * A remark-parse tokenizer to add support for jekyll style link definitions, which have spaces in the link
+ *
+ * For more information see:
+ * - https://github.com/remarkjs/remark/tree/master/packages/remark-parse#extending-the-parser
+ */
+function jekyllLinkDefinition() {
+    var Parser = this.Parser;
+    var tokenizers = Parser.prototype.inlineTokenizers;
+    var methods = Parser.prototype.inlineMethods;
+
+    // Add a new inline tokenizer
+    tokenizers.jekyllLinkDefinition = tokenizer;
+
+    // Run it just before `link`.
+    methods.splice(methods.indexOf('link'), 0, 'jekyllLinkDefinition');
+}
+
+// The tokenizer function to use during parsing
+function tokenizer(eat, value, silent) {
+    // This regex checks to see if a value looks like a markdown link definition
+    var match = /^\[([^\]]+)\]:\s?(.*)/.exec(value);
+
+    if (match) {
+        if (silent) {
+            return true;
+        }
+
+        // Create new definition node based on captured values
+        // See: https://github.com/syntax-tree/mdast#definition
+        let newNode = {
+            type: 'definition',
+            identifier: match[1],
+            label: match[1],
+            url: match[2]
+        };
+
+        // Consume the matching text from value (returns a function for adding a new node)
+        // See: https://github.com/remarkjs/remark/tree/master/packages/remark-parse#eatsubvalue
+        const add = eat(match[0]);
+
+        // Add the new node to the currently processed node
+        // See: https://github.com/remarkjs/remark/tree/master/packages/remark-parse#addnode-parent
+        return add(newNode);
+    }
+}
+
+// Add a locator for the tokenizer. This is required for inline tokenizers.
+// See: https://github.com/remarkjs/remark/tree/master/packages/remark-parse#tokenizerlocatorvalue-fromindex
+tokenizer.locator = (value, fromIndex) => {
+    return value.indexOf('[', fromIndex);
+};
+
+module.exports = jekyllLinkDefinition;

--- a/pwa-devdocs/scripts/markdown-linter/tokenizers/jekyll-link.js
+++ b/pwa-devdocs/scripts/markdown-linter/tokenizers/jekyll-link.js
@@ -1,5 +1,6 @@
 /**
- * A remark-parse tokenizer to add support for jekyll style link definitions, which have spaces in the link
+ * A remark-parse tokenizer to add support for jekyll style link definitions 
+ * These definitions have spaces in the link and are not correctly parsed
  *
  * For more information see:
  * - https://github.com/remarkjs/remark/tree/master/packages/remark-parse#extending-the-parser
@@ -12,11 +13,18 @@ function jekyllLinkDefinition() {
     // Add a new inline tokenizer
     tokenizers.jekyllLinkDefinition = tokenizer;
 
-    // Run it just before `link`.
+    // Run it just before the `link` tokenizer.
     methods.splice(methods.indexOf('link'), 0, 'jekyllLinkDefinition');
 }
 
-// The tokenizer function to use during parsing
+/**
+ * The tokenizer function to use during parsing
+ * @param eat (function) A function used for consuming parts of a string and returning
+ *                       a function for adding a node to a syntax tree
+ * @param value (string) A value that may contain the value we are looking for
+ * @param silent (boolean) Whether the parser should just detect the existence of the pattern
+ *                       or also consume it
+ */
 function tokenizer(eat, value, silent) {
     // This regex checks to see if a value looks like a markdown link definition
     var match = /^\[([^\]]+)\]:\s?(.*)/.exec(value);

--- a/pwa-devdocs/scripts/markdown-linter/tokenizers/jekyll-link.js
+++ b/pwa-devdocs/scripts/markdown-linter/tokenizers/jekyll-link.js
@@ -1,20 +1,23 @@
 /**
- * A remark-parse tokenizer to add support for jekyll style link definitions 
+ * A remark-parse tokenizer to add support for jekyll style link definitions
  * These definitions have spaces in the link and are not correctly parsed
  *
  * For more information see:
  * - https://github.com/remarkjs/remark/tree/master/packages/remark-parse#extending-the-parser
  */
+
+const TOKENIZER_NAME = 'jekyllLinkDefinition';
+
 function jekyllLinkDefinition() {
-    var Parser = this.Parser;
-    var tokenizers = Parser.prototype.inlineTokenizers;
-    var methods = Parser.prototype.inlineMethods;
+    const Parser = this.Parser;
+    const tokenizers = Parser.prototype.inlineTokenizers;
+    const methods = Parser.prototype.inlineMethods;
 
     // Add a new inline tokenizer
-    tokenizers.jekyllLinkDefinition = tokenizer;
+    tokenizers[TOKENIZER_NAME] = tokenizer;
 
     // Run it just before the `link` tokenizer.
-    methods.splice(methods.indexOf('link'), 0, 'jekyllLinkDefinition');
+    methods.splice(methods.indexOf('link'), 0, TOKENIZER_NAME);
 }
 
 /**
@@ -27,7 +30,8 @@ function jekyllLinkDefinition() {
  */
 function tokenizer(eat, value, silent) {
     // This regex checks to see if a value looks like a markdown link definition
-    var match = /^\[([^\]]+)\]:\s?(.*)/.exec(value);
+    // Example: [link definition]: {{site.baseurl}}{% link /some/topic/index.md %}
+    const match = /^\[([^\]]+)\]:\s?(.*)/.exec(value);
 
     if (match) {
         if (silent) {

--- a/pwa-devdocs/src/venia-pwa-concept/design/colors/index.md
+++ b/pwa-devdocs/src/venia-pwa-concept/design/colors/index.md
@@ -4,17 +4,17 @@ title: Colors
 
 The Venia storefront uses the following colors in its design.
 
-| Color       | Hex       | Description |
-| ----------- | --------- | ----------- |
-| ![007378][] | `#007378` | |
-| ![D4F3EE][] | `#D4F3EE` | |
-| ![212121][] | `#212121` | |
-| ![707070][] | `#707070` | |
-| ![9E9E9E][] | `#9E9E9E` | |
-| ![D1D1D1][] | `#D1D1D1` | |
-| ![F6F6F6][] | `#F6F6F6` | |
-| ![C0123F][] | `#C0123F` | |
-| ![FFE2EA][] | `#FFE2EA` | |
+| Color       | Hex       | Rgb |Description |
+| ----------- | --------- | --------|----------- |
+| ![007378][] | `#007378` | `rgb(0,115,120)`||
+| ![D4F3EE][] | `#D4F3EE` | `rgb(212,243,238)`||
+| ![212121][] | `#212121` | `rgb(33,33,33)`||
+| ![707070][] | `#707070` | `rgb(112,112,112)`||
+| ![9E9E9E][] | `#9E9E9E` | `rgb(158,158,158)`||
+| ![D1D1D1][] | `#D1D1D1` | `rgb(209,209,209)`||
+| ![F6F6F6][] | `#F6F6F6` | `rgb(246,246,246)`||
+| ![C0123F][] | `#C0123F` | `rgb(192,18,63)`||
+| ![FFE2EA][] | `#FFE2EA` | `rgb(255,226,234)`||
 {: style="table-layout:auto;"}
 
 [FFE2EA]: {{site.baseurl}}{%link venia-pwa-concept/design/colors/images/color-FFE2EA.png %}


### PR DESCRIPTION
## Description

Adds the ability to specify a directory for linting.

Adds a new tokenizer that allows the parsing of link definitions that have spaces. This is not standard markdown, but the syntax is commonly used in Jekyll markdown files for internal links.

## Related Issue

Closes #1176 

## Verification Steps

1. Go to the `pwa-devdocs` project directory
2. Run `npm run lint src/tutorials`
3. See linting results for all markdown files in the `src/tutorials` directory
4. Verify that no false positive warnings about undefined link definitions logged

## How Have YOU Tested this?

See **Verification Steps**

## Screenshots / Screen Captures (if appropriate):

n/a

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly, if necessary.
- [ ] I have added tests to cover my changes, if necessary.
