### PR TITLE
Fixed  #1104 Mini-cart Sidebar: If cart is empty and clicked on minicart

### DIFF
--- a/packages/venia-concept/src/actions/cart/asyncActions.js
+++ b/packages/venia-concept/src/actions/cart/asyncActions.js
@@ -1,4 +1,5 @@
 import { RestApi, Util } from '@magento/peregrine';
+import { isUndefined } from 'util';
 
 import { closeDrawer, toggleDrawer } from 'src/actions/app';
 import checkoutActions from 'src/actions/checkout';
@@ -425,7 +426,7 @@ async function fetchCartPart({
     isSignedIn,
     subResource = ''
 }, sendRequest) {
-    if (sendRequest) {
+    if (sendRequest || isUndefined(sendRequest)) {
         const signedInEndpoint = `/rest/V1/carts/mine/${subResource}`;
         const guestEndpoint = `/rest/V1/guest-carts/${cartId}/${subResource}`;
         const endpoint = isSignedIn ? signedInEndpoint : guestEndpoint;

--- a/packages/venia-concept/src/actions/cart/asyncActions.js
+++ b/packages/venia-concept/src/actions/cart/asyncActions.js
@@ -1,9 +1,10 @@
 import { RestApi, Util } from '@magento/peregrine';
-import { isUndefined } from 'util';
 
 import { closeDrawer, toggleDrawer } from 'src/actions/app';
 import checkoutActions from 'src/actions/checkout';
 import actions from './actions';
+
+import { isUndefined } from 'util';
 
 const { request } = RestApi.Magento2;
 const { BrowserPersistence } = Util;
@@ -311,34 +312,37 @@ export const getCartDetails = (payload = {}) => {
         dispatch(actions.getDetails.request(cartId));
 
         try {
-            const [
-                imageCache,
-                details
-            ] = await Promise.all([
+            const [imageCache, details] = await Promise.all([
                 retrieveImageCache(),
-                fetchCartPart({
-                    cartId,
-                    forceRefresh,
-                    isSignedIn
-                }, true)
+                fetchCartPart(
+                    {
+                        cartId,
+                        forceRefresh,
+                        isSignedIn
+                    },
+                    true
+                )
             ]);
 
-            const [
-                paymentMethods,
-                totals
-            ] = await Promise.all([
-                fetchCartPart({
-                    cartId,
-                    forceRefresh,
-                    isSignedIn,
-                    subResource: 'payment-methods'
-                }, details.items.length > 0),
-                fetchCartPart({
-                    cartId,
-                    forceRefresh,
-                    isSignedIn,
-                    subResource: 'totals'
-                }, details.items.length > 0)
+            const [paymentMethods, totals] = await Promise.all([
+                fetchCartPart(
+                    {
+                        cartId,
+                        forceRefresh,
+                        isSignedIn,
+                        subResource: 'payment-methods'
+                    },
+                    details.items.length > 0
+                ),
+                fetchCartPart(
+                    {
+                        cartId,
+                        forceRefresh,
+                        isSignedIn,
+                        subResource: 'totals'
+                    },
+                    details.items.length > 0
+                )
             ]);
             const { items } = details;
 
@@ -420,12 +424,10 @@ export const removeCart = () =>
 
 /* helpers */
 
-async function fetchCartPart({
-    cartId,
-    forceRefresh,
-    isSignedIn,
-    subResource = ''
-}, sendRequest) {
+async function fetchCartPart(
+    { cartId, forceRefresh, isSignedIn, subResource = '' },
+    sendRequest
+) {
     if (sendRequest || isUndefined(sendRequest)) {
         const signedInEndpoint = `/rest/V1/carts/mine/${subResource}`;
         const guestEndpoint = `/rest/V1/guest-carts/${cartId}/${subResource}`;


### PR DESCRIPTION
Fixed  #1104 Mini-cart Sidebar: If cart is empty and clicked on mini-cart, execute unwanted Rest API call.

**Describe the bug**

I've noticed extra or unwanted Rest API call executed on mini-cart open action even cart is empty.

**To Reproduce**
Steps to reproduce the behaviour:

Go to the pwa-studio storefront.
Open developer console and go to the network tab.
Click on the mini-cart icon at the top right section.
See you will find rest API call even cart is empty.

**Expected behavior**
If the cart is empty, the rest API call shouldn't be executed.

Screenshots
https://user-images.githubusercontent.com/38535982/55396761-4720d200-5562-11e9-9f24-941064c46689.png

Please complete the following device information:

Device: iPhone6/7/8, PC
OS: Ubuntu
Browser Chrome
Magento Version 2.3.1
PWA Studio Version: 2.1
NPM version 6.4.1
Node Version 10.15.2
Please let us know what packages this bug is in regards to:

  venia-concept
  pwa-buildpack
  peregrine
  pwa-devdocs
  upward-js
  upward-spec
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly, if necessary.
- [ ] I have added tests to cover my changes, if necessary.
