### PR TITLE
Fixed # 1159

### DIFF
--- a/packages/venia-concept/src/RootComponents/Product/Product.js
+++ b/packages/venia-concept/src/RootComponents/Product/Product.js
@@ -1,6 +1,8 @@
 import React, { Component } from 'react';
 import { string, func } from 'prop-types';
 
+import { isUndefined } from 'util';
+
 import { connect, Query } from 'src/drivers';
 import { addItemToCart } from 'src/actions/cart';
 import { loadingIndicator } from 'src/components/LoadingIndicator';
@@ -32,12 +34,17 @@ class Product extends Component {
 
     // map Magento 2.3.1 schema changes to Venia 2.0.0 proptype shape to maintain backwards compatibility
     mapProduct(product) {
-        const { description } = product;
-        return {
-            ...product,
-            description:
-                typeof description === 'object' ? description.html : description
-        };
+        if (!isUndefined(product)) {
+            const { description } = product;
+            return {
+                ...product,
+                description:
+                    typeof description === 'object'
+                        ? description.html
+                        : description
+            };
+        }
+        return false;
     }
 
     render() {
@@ -51,13 +58,17 @@ class Product extends Component {
                     if (loading) return loadingIndicator;
 
                     const product = data.productDetail.items[0];
-
-                    return (
-                        <ProductFullDetail
-                            product={this.mapProduct(product)}
-                            addToCart={this.props.addItemToCart}
-                        />
-                    );
+                    const productData = this.mapProduct(product);
+                    if (productData) {
+                        return (
+                            <ProductFullDetail
+                                product={this.mapProduct(product)}
+                                addToCart={this.props.addItemToCart}
+                            />
+                        );
+                    } else {
+                        return <div>Product Out Of Stock</div>;
+                    }
                 }}
             </Query>
         );


### PR DESCRIPTION
Fixed # 1159 If user tries to access product page after it goes to out of stock then system enters a infinite loop.
Steps -

Access a product details page say for Product A.
Login to backend and make Product A as out of stock.
Now either refresh the product details page on storefront venia or try accessing the product again.
Expected - System should throw error message indicating product not available.
Actual - System show error notification and if user click on in the same error re-appears. User has to clear browser cache to make it work.

Screen -
https://camo.githubusercontent.com/5a1d45ba88b755e5de57d808bcbe38167156fb7a/68747470733a2f2f696d616765732e7a656e68756275736572636f6e74656e742e636f6d2f3563353835633561656362303037366633653839383433312f35656164613138362d326165642d343836362d626562372d366438333065313462393134
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly, if necessary.
- [ ] I have added tests to cover my changes, if necessary.
