### PR TITLE
Bug/thumbnails are requested twice in desktop mode

### DIFF
--- a/packages/venia-concept/src/components/ImageLazyLoader/ImageLazyLoader.js
+++ b/packages/venia-concept/src/components/ImageLazyLoader/ImageLazyLoader.js
@@ -4,7 +4,7 @@ import classify from 'src/classify';
 
 import defaultClasses from './imageLazyLoader.css';
 
-const ImageLazyLoader = ({ classes, src, ...props }) => {
+const ImageLazyLoader = ({ classes, alt, src, ...props }) => {
     const [isLoaded, setLoaded] = useState(false);
 
     return (
@@ -15,6 +15,7 @@ const ImageLazyLoader = ({ classes, src, ...props }) => {
             }`}
             onLoad={() => setLoaded(true)}
             src={src}
+            alt={alt}
         />
     );
 };
@@ -24,6 +25,7 @@ ImageLazyLoader.propTypes = {
         loading: string,
         loaded: string
     }),
+    alt: string,
     src: string.isRequired
 };
 

--- a/packages/venia-concept/src/components/ImageLazyLoader/ImageLazyLoader.js
+++ b/packages/venia-concept/src/components/ImageLazyLoader/ImageLazyLoader.js
@@ -1,0 +1,30 @@
+import React, { useState } from 'react';
+import { shape, string } from 'prop-types';
+import classify from 'src/classify';
+
+import defaultClasses from './imageLazyLoader.css';
+
+const ImageLazyLoader = ({ classes, src, ...props }) => {
+    const [isLoaded, setLoaded] = useState(false);
+
+    return (
+        <img
+            {...props}
+            className={`${classes.root} ${
+                !!isLoaded ? classes.loaded : classes.loading
+            }`}
+            onLoad={() => setLoaded(true)}
+            src={src}
+        />
+    );
+};
+
+ImageLazyLoader.propTypes = {
+    classes: shape({
+        loading: string,
+        loaded: string
+    }),
+    src: string.isRequired
+};
+
+export default classify(defaultClasses)(ImageLazyLoader);

--- a/packages/venia-concept/src/components/ImageLazyLoader/imageLazyLoader.css
+++ b/packages/venia-concept/src/components/ImageLazyLoader/imageLazyLoader.css
@@ -1,0 +1,11 @@
+.loading {
+    opacity: 0;
+    visibility: hidden;
+    transition: all 0.3s ease;
+}
+
+.loaded {
+    opacity: 1;
+    visibility: visible;
+    transition: all 0.3s ease;
+}

--- a/packages/venia-concept/src/components/ImageLazyLoader/index.js
+++ b/packages/venia-concept/src/components/ImageLazyLoader/index.js
@@ -1,0 +1,1 @@
+export { default } from './ImageLazyLoader';

--- a/packages/venia-concept/src/components/ProductImageCarousel/thumbnail.js
+++ b/packages/venia-concept/src/components/ProductImageCarousel/thumbnail.js
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import { resourceUrl } from 'src/drivers';
 import { mergeClasses } from 'src/classify';
 import defaultClasses from './thumbnail.css';
+import ImageLazyLoader from 'src/components/ImageLazyLoader';
 import { transparentPlaceholder } from 'src/shared/images';
 import { useWindowSize } from '@magento/peregrine';
 
@@ -35,7 +36,11 @@ function Thumbnail(props) {
             className={isActive ? classes.rootSelected : classes.root}
         >
             {isDesktop ? (
-                <img className={classes.image} src={src} alt={label} />
+                <ImageLazyLoader
+                    className={classes.image}
+                    src={src}
+                    alt={label}
+                />
             ) : null}
         </button>
     );

--- a/packages/venia-concept/src/components/ProductImageCarousel/thumbnailList.js
+++ b/packages/venia-concept/src/components/ProductImageCarousel/thumbnailList.js
@@ -1,4 +1,4 @@
-import React  from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import { List } from '@magento/peregrine';
 

--- a/packages/venia-concept/src/components/ProductImageCarousel/thumbnailList.js
+++ b/packages/venia-concept/src/components/ProductImageCarousel/thumbnailList.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import { List } from '@magento/peregrine';
 
@@ -6,45 +6,44 @@ import classify from 'src/classify';
 import Thumbnail from './thumbnail';
 import defaultClasses from './thumbnailList.css';
 
-class ThumbnailList extends Component {
-    static propTypes = {
-        activeItemIndex: PropTypes.number,
-        classes: PropTypes.shape({
-            root: PropTypes.string
-        }),
-        items: PropTypes.arrayOf(
-            PropTypes.shape({
-                label: PropTypes.string,
-                position: PropTypes.number,
-                disabled: PropTypes.bool,
-                file: PropTypes.string.isRequired
-            })
-        ).isRequired,
-        updateActiveItemIndex: PropTypes.func.isRequired
-    };
+const ThumbnailList = ({
+    activeItemIndex,
+    updateActiveItemIndex,
+    items,
+    classes
+}) => {
+    return (
+        <List
+            items={items}
+            renderItem={props => (
+                <Thumbnail
+                    {...props}
+                    isActive={activeItemIndex === props.itemIndex}
+                    onClickHandler={newActiveItemIndex =>
+                        updateActiveItemIndex(newActiveItemIndex)
+                    }
+                />
+            )}
+            getItemKey={i => i.file}
+            classes={classes}
+        />
+    );
+};
 
-    updateActiveItemHandler = newActiveItemIndex => {
-        this.props.updateActiveItemIndex(newActiveItemIndex);
-    };
-
-    render() {
-        const { activeItemIndex, items, classes } = this.props;
-
-        return (
-            <List
-                items={items}
-                renderItem={props => (
-                    <Thumbnail
-                        {...props}
-                        isActive={activeItemIndex === props.itemIndex}
-                        onClickHandler={this.updateActiveItemHandler}
-                    />
-                )}
-                getItemKey={i => i.file}
-                classes={classes}
-            />
-        );
-    }
-}
+ThumbnailList.propTypes = {
+    activeItemIndex: PropTypes.number,
+    classes: PropTypes.shape({
+        root: PropTypes.string
+    }),
+    items: PropTypes.arrayOf(
+        PropTypes.shape({
+            label: PropTypes.string,
+            position: PropTypes.number,
+            disabled: PropTypes.bool,
+            file: PropTypes.string.isRequired
+        })
+    ).isRequired,
+    updateActiveItemIndex: PropTypes.func.isRequired
+};
 
 export default classify(defaultClasses)(ThumbnailList);

--- a/packages/venia-concept/src/components/ProductImageCarousel/thumbnailList.js
+++ b/packages/venia-concept/src/components/ProductImageCarousel/thumbnailList.js
@@ -1,4 +1,4 @@
-import React, { PureComponent } from 'react';
+import React  from 'react';
 import PropTypes from 'prop-types';
 import { List } from '@magento/peregrine';
 


### PR DESCRIPTION
## Description
Loading the main image re-loads the images from the thumbnails. It was related to the change of the main component of the gallery. When he changed children (thumbnails) they were re-rendered.

I added a component responsible for lazy loading pictures that holds the state whether the image is already loaded. Therefore, I made a refactor of Carousel, ThumbnailList and Thumbnail components.

## Related Issue
Closes #1231

## Verification Steps
1. Open browser console (Network section filtered only by Img in chrome) and go to product page.
2. Confirm that all images are loaded only once.
3. Change active image from thumbnails
4. Confirm that all images are loaded only once.

## How Have YOU Tested this?
1. The verification steps above


## Proposed Labels for Change Type/Package
- [ ] major (e.g x.0.0 - a breaking change)
- [ ] minor (e.g 0.x.0 - a backwards compatible addition)
- [x] patch (e.g 0.0.x - a bug fix)

## Checklist:
- [ ] I have updated the documentation accordingly, if necessary.
- [ ] I have added tests to cover my changes, if necessary.
