### PR TITLE
[bug]: Incorrect Order Id Displayed - Replacing functionality

### DIFF
--- a/packages/venia-concept/src/actions/checkout/asyncActions.js
+++ b/packages/venia-concept/src/actions/checkout/asyncActions.js
@@ -280,12 +280,6 @@ export const createAccount = history => async (dispatch, getState) => {
     history.push(`/create-account?${new URLSearchParams(accountInfo)}`);
 };
 
-export const continueShopping = history => async dispatch => {
-    await dispatch(resetCheckout());
-
-    history.push('/');
-};
-
 /* helpers */
 
 export function formatAddress(address = {}, countries = []) {

--- a/packages/venia-concept/src/components/Checkout/Receipt/__tests__/__snapshots__/receipt.spec.js.snap
+++ b/packages/venia-concept/src/components/Checkout/Receipt/__tests__/__snapshots__/receipt.spec.js.snap
@@ -15,28 +15,10 @@ exports[`renders a Receipt component correctly 1`] = `
     <div
       className="textBlock"
     >
-      Your order # is
-       
-      <span
-        className="orderId"
-      >
-        123
-      </span>
+      You will receive an order confirmation email with order status and other details.
       <br />
-      We’ll email you an order confirmation with details and tracking info
     </div>
-    <button
-      className="root_normalPriority"
-      data-id="continue-shopping-button"
-      onClick={[Function]}
-      type="button"
-    >
-      <span
-        className="content"
-      >
-        Continue Shopping
-      </span>
-    </button>
+    <hr />
     <div
       className="textBlock"
     >

--- a/packages/venia-concept/src/components/Checkout/Receipt/__tests__/__snapshots__/receipt.spec.js.snap
+++ b/packages/venia-concept/src/components/Checkout/Receipt/__tests__/__snapshots__/receipt.spec.js.snap
@@ -16,7 +16,6 @@ exports[`renders a Receipt component correctly 1`] = `
       className="textBlock"
     >
       You will receive an order confirmation email with order status and other details.
-      <br />
     </div>
     <hr />
     <div
@@ -26,7 +25,6 @@ exports[`renders a Receipt component correctly 1`] = `
     </div>
     <button
       className="root_highPriority"
-      data-id="create-account-button"
       onClick={[Function]}
       type="button"
     >

--- a/packages/venia-concept/src/components/Checkout/Receipt/__tests__/__snapshots__/receipt.spec.js.snap
+++ b/packages/venia-concept/src/components/Checkout/Receipt/__tests__/__snapshots__/receipt.spec.js.snap
@@ -21,7 +21,7 @@ exports[`renders a Receipt component correctly 1`] = `
     <div
       className="textBlock"
     >
-      Track order status and earn rewards for your purchase by creating and account.
+      Track order status and earn rewards for your purchase by creating an account.
     </div>
     <button
       className="root_highPriority"

--- a/packages/venia-concept/src/components/Checkout/Receipt/__tests__/receipt.spec.js
+++ b/packages/venia-concept/src/components/Checkout/Receipt/__tests__/receipt.spec.js
@@ -1,10 +1,9 @@
 import React from 'react';
-import testRenderer from 'react-test-renderer';
+import testRenderer, { act } from 'react-test-renderer';
+import { createTestInstance } from '@magento/peregrine';
 import { shallow } from 'enzyme';
-import Receipt, {
-    CREATE_ACCOUNT_BUTTON_ID,
-    CONTINUE_SHOPPING_BUTTON_ID
-} from '../receipt';
+
+import Receipt, { CREATE_ACCOUNT_BUTTON_ID } from '../receipt';
 
 const classes = {
     header: 'header',
@@ -17,7 +16,6 @@ const userProp = { isSignedIn: false };
 
 test('renders a Receipt component correctly', () => {
     const props = {
-        continueShopping: jest.fn(),
         order: { id: '123' },
         createAccount: jest.fn(),
         reset: jest.fn(),
@@ -29,23 +27,6 @@ test('renders a Receipt component correctly', () => {
     expect(component.toJSON()).toMatchSnapshot();
 });
 
-test('calls `handleContinueShopping` when `Continue Shopping` button is pressed', () => {
-    const handleContinueShoppingMock = jest.fn();
-
-    const wrapper = shallow(
-        <Receipt
-            continueShopping={handleContinueShoppingMock}
-            classes={classes}
-            user={userProp}
-        />
-    ).dive();
-    wrapper
-        .findWhere(el => el.prop('data-id') === CONTINUE_SHOPPING_BUTTON_ID)
-        .first()
-        .simulate('click');
-    expect(handleContinueShoppingMock).toBeCalled();
-});
-
 test('calls `handleCreateAccount` when `Create an Account` button is pressed', () => {
     const handleCreateAccountMock = jest.fn();
 
@@ -55,7 +36,7 @@ test('calls `handleCreateAccount` when `Create an Account` button is pressed', (
             classes={classes}
             user={userProp}
         />
-    ).dive();
+    );
 
     wrapper
         .findWhere(el => el.prop('data-id') === CREATE_ACCOUNT_BUTTON_ID)
@@ -68,11 +49,13 @@ test('calls `handleCreateAccount` when `Create an Account` button is pressed', (
 test('calls `reset` when component was unmounted', () => {
     const resetHandlerMock = jest.fn();
 
-    const wrapper = shallow(
+    const instance = createTestInstance(
         <Receipt reset={resetHandlerMock} classes={classes} user={userProp} />
-    ).dive();
+    );
 
-    wrapper.unmount();
+    act(() => {
+        instance.unmount();
+    });
 
     expect(resetHandlerMock).toBeCalled();
 });

--- a/packages/venia-concept/src/components/Checkout/Receipt/__tests__/receipt.spec.js
+++ b/packages/venia-concept/src/components/Checkout/Receipt/__tests__/receipt.spec.js
@@ -3,7 +3,8 @@ import testRenderer, { act } from 'react-test-renderer';
 import { createTestInstance } from '@magento/peregrine';
 import { shallow } from 'enzyme';
 
-import Receipt, { CREATE_ACCOUNT_BUTTON_ID } from '../receipt';
+import Receipt from '../receipt';
+import Button from 'src/components/Button';
 
 const classes = {
     header: 'header',
@@ -38,10 +39,7 @@ test('calls `handleCreateAccount` when `Create an Account` button is pressed', (
         />
     );
 
-    wrapper
-        .findWhere(el => el.prop('data-id') === CREATE_ACCOUNT_BUTTON_ID)
-        .first()
-        .simulate('click');
+    wrapper.find(Button).simulate('click');
 
     expect(handleCreateAccountMock).toBeCalled();
 });

--- a/packages/venia-concept/src/components/Checkout/Receipt/__tests__/receiptContainer.spec.js
+++ b/packages/venia-concept/src/components/Checkout/Receipt/__tests__/receiptContainer.spec.js
@@ -1,5 +1,5 @@
 import actions from 'src/actions/checkoutReceipt';
-import { continueShopping, createAccount } from 'src/actions/checkout';
+import { createAccount } from 'src/actions/checkout';
 import Container from '../receiptContainer';
 import Receipt from '../receipt';
 
@@ -24,7 +24,6 @@ test('returns a connected Receipt component', () => {
     expect(Container.component).toBe(Receipt);
     expect(Container.mapStateToProps).toBeInstanceOf(Function);
     expect(Container.mapDispatchToProps).toMatchObject({
-        continueShopping,
         createAccount,
         reset: actions.reset
     });

--- a/packages/venia-concept/src/components/Checkout/Receipt/receipt.js
+++ b/packages/venia-concept/src/components/Checkout/Receipt/receipt.js
@@ -4,9 +4,6 @@ import { mergeClasses } from 'src/classify';
 import Button from 'src/components/Button';
 import defaultClasses from './receipt.css';
 
-export const VIEW_ORDER_DETAILS_BUTTON_ID = 'view-order-details-button';
-export const CREATE_ACCOUNT_BUTTON_ID = 'create-account-button';
-
 const Receipt = props => {
     const { createAccount, history, order, reset, user } = props;
 
@@ -33,12 +30,10 @@ const Receipt = props => {
                 {user.isSignedIn ? (
                     <Fragment>
                         <div className={classes.textBlock}>
-                            You can also visit your account page for more information.
+                            You can also visit your account page for more
+                            information.
                         </div>
-                        <Button
-                            data-id={VIEW_ORDER_DETAILS_BUTTON_ID}
-                            onClick={handleViewOrderDetails}
-                        >
+                        <Button onClick={handleViewOrderDetails}>
                             View Order Details
                         </Button>
                     </Fragment>
@@ -49,11 +44,7 @@ const Receipt = props => {
                             Track order status and earn rewards for your
                             purchase by creating and account.
                         </div>
-                        <Button
-                            data-id={CREATE_ACCOUNT_BUTTON_ID}
-                            priority="high"
-                            onClick={handleCreateAccount}
-                        >
+                        <Button priority="high" onClick={handleCreateAccount}>
                             Create an Account
                         </Button>
                     </Fragment>

--- a/packages/venia-concept/src/components/Checkout/Receipt/receipt.js
+++ b/packages/venia-concept/src/components/Checkout/Receipt/receipt.js
@@ -1,4 +1,4 @@
-import React, { Fragment, useCallback, useEffect } from 'react';
+import React, { useCallback, useEffect } from 'react';
 import { bool, func, shape, string } from 'prop-types';
 import { mergeClasses } from 'src/classify';
 import Button from 'src/components/Button';
@@ -8,15 +8,11 @@ export const VIEW_ORDER_DETAILS_BUTTON_ID = 'view-order-details-button';
 export const CREATE_ACCOUNT_BUTTON_ID = 'create-account-button';
 
 const Receipt = props => {
-    const { createAccount, history, reset, user } = props;
+    const { createAccount, history, order, reset, user } = props;
 
     const classes = mergeClasses(defaultClasses, props.classes);
 
-    useEffect(() => {
-        return () => {
-            reset();
-        };
-    }, [reset]);
+    useEffect(() => reset, [reset]);
 
     const handleCreateAccount = useCallback(() => {
         createAccount(history);
@@ -24,46 +20,59 @@ const Receipt = props => {
 
     const handleViewOrderDetails = useCallback(() => {
         // TODO: Implement/connect/redirect to order details page.
-    }, [props.order]);
+    }, [order]);
 
-    return (
-        <div className={classes.root}>
-            <div className={classes.body}>
-                <h2 className={classes.header}>Thank you for your purchase!</h2>
-                <div className={classes.textBlock}>
-                    You will receive an order confirmation email with order
-                    status and other details.
-                    <br />
-                    {user.isSignedIn &&
-                        'You can also visit your account page for more information.'}
-                </div>
-                {user.isSignedIn && (
+    if (user.isSignedIn) {
+        return (
+            <div className={classes.root}>
+                <div className={classes.body}>
+                    <h2 className={classes.header}>
+                        Thank you for your purchase!
+                    </h2>
+                    <div className={classes.textBlock}>
+                        You will receive an order confirmation email with order
+                        status and other details.
+                        <br />
+                        You can also visit your account page for more
+                        information.
+                    </div>
                     <Button
                         data-id={VIEW_ORDER_DETAILS_BUTTON_ID}
                         onClick={handleViewOrderDetails}
                     >
                         View Order Details
                     </Button>
-                )}
-                {!user.isSignedIn && (
-                    <Fragment>
-                        <hr />
-                        <div className={classes.textBlock}>
-                            Track order status and earn rewards for your
-                            purchase by creating and account.
-                        </div>
-                        <Button
-                            data-id={CREATE_ACCOUNT_BUTTON_ID}
-                            priority="high"
-                            onClick={handleCreateAccount}
-                        >
-                            Create an Account
-                        </Button>
-                    </Fragment>
-                )}
+                </div>
             </div>
-        </div>
-    );
+        );
+    } else {
+        return (
+            <div className={classes.root}>
+                <div className={classes.body}>
+                    <h2 className={classes.header}>
+                        Thank you for your purchase!
+                    </h2>
+                    <div className={classes.textBlock}>
+                        You will receive an order confirmation email with order
+                        status and other details.
+                        <br />
+                    </div>
+                    <hr />
+                    <div className={classes.textBlock}>
+                        Track order status and earn rewards for your purchase by
+                        creating and account.
+                    </div>
+                    <Button
+                        data-id={CREATE_ACCOUNT_BUTTON_ID}
+                        priority="high"
+                        onClick={handleCreateAccount}
+                    >
+                        Create an Account
+                    </Button>
+                </div>
+            </div>
+        );
+    }
 };
 
 Receipt.propTypes = {

--- a/packages/venia-concept/src/components/Checkout/Receipt/receipt.js
+++ b/packages/venia-concept/src/components/Checkout/Receipt/receipt.js
@@ -1,93 +1,91 @@
-import React, { Component, Fragment } from 'react';
+import React, { Fragment, useCallback, useEffect } from 'react';
 import { bool, func, shape, string } from 'prop-types';
-import classify from 'src/classify';
+import { mergeClasses } from 'src/classify';
 import Button from 'src/components/Button';
 import defaultClasses from './receipt.css';
 
-export const CONTINUE_SHOPPING_BUTTON_ID = 'continue-shopping-button';
+export const VIEW_ORDER_DETAILS_BUTTON_ID = 'view-order-details-button';
 export const CREATE_ACCOUNT_BUTTON_ID = 'create-account-button';
 
-class Receipt extends Component {
-    static propTypes = {
-        classes: shape({
-            body: string,
-            footer: string,
-            root: string
-        }),
-        continueShopping: func.isRequired,
-        order: shape({
-            id: string
-        }).isRequired,
-        createAccount: func.isRequired,
-        reset: func.isRequired,
-        user: shape({
-            isSignedIn: bool
-        })
-    };
+const Receipt = props => {
+    const { createAccount, history, reset, user } = props;
 
-    static defaultProps = {
-        order: {},
-        continueShopping: () => {},
-        reset: () => {},
-        createAccount: () => {}
-    };
+    const classes = mergeClasses(defaultClasses, props.classes);
 
-    componentWillUnmount() {
-        this.props.reset();
-    }
+    useEffect(() => {
+        return () => {
+            reset();
+        };
+    }, [reset]);
 
-    createAccount = () => {
-        this.props.createAccount(this.props.history);
-    };
+    const handleCreateAccount = useCallback(() => {
+        createAccount(history);
+    }, [createAccount, history]);
 
-    continueShopping = () => {
-        this.props.continueShopping(this.props.history);
-    };
+    const handleViewOrderDetails = useCallback(() => {
+        // TODO: Implement/connect/redirect to order details page.
+    }, [props.order]);
 
-    render() {
-        const {
-            classes,
-            order: { id },
-            user
-        } = this.props;
-
-        return (
-            <div className={classes.root}>
-                <div className={classes.body}>
-                    <h2 className={classes.header}>
-                        Thank you for your purchase!
-                    </h2>
-                    <div className={classes.textBlock}>
-                        Your order # is{' '}
-                        <span className={classes.orderId}>{id}</span>
-                        <br />
-                        We&rsquo;ll email you an order confirmation with details
-                        and tracking info
-                    </div>
-                    <Button
-                        data-id={CONTINUE_SHOPPING_BUTTON_ID}
-                        onClick={this.continueShopping}
-                    >
-                        Continue Shopping
-                    </Button>
-                    {!user.isSignedIn && (
-                        <Fragment>
-                            <div className={classes.textBlock}>
-                                Track order status and earn rewards for your
-                                purchase by creating and account.
-                            </div>
-                            <Button
-                                data-id={CREATE_ACCOUNT_BUTTON_ID}
-                                priority="high"
-                                onClick={this.createAccount}
-                            >
-                                Create an Account
-                            </Button>
-                        </Fragment>
-                    )}
+    return (
+        <div className={classes.root}>
+            <div className={classes.body}>
+                <h2 className={classes.header}>Thank you for your purchase!</h2>
+                <div className={classes.textBlock}>
+                    You will receive an order confirmation email with order
+                    status and other details.
+                    <br />
+                    {user.isSignedIn &&
+                        'You can also visit your account page for more information.'}
                 </div>
+                {user.isSignedIn && (
+                    <Button
+                        data-id={VIEW_ORDER_DETAILS_BUTTON_ID}
+                        onClick={handleViewOrderDetails}
+                    >
+                        View Order Details
+                    </Button>
+                )}
+                {!user.isSignedIn && (
+                    <Fragment>
+                        <hr />
+                        <div className={classes.textBlock}>
+                            Track order status and earn rewards for your
+                            purchase by creating and account.
+                        </div>
+                        <Button
+                            data-id={CREATE_ACCOUNT_BUTTON_ID}
+                            priority="high"
+                            onClick={handleCreateAccount}
+                        >
+                            Create an Account
+                        </Button>
+                    </Fragment>
+                )}
             </div>
-        );
-    }
-}
-export default classify(defaultClasses)(Receipt);
+        </div>
+    );
+};
+
+Receipt.propTypes = {
+    classes: shape({
+        body: string,
+        footer: string,
+        root: string
+    }),
+    order: shape({
+        id: string
+    }).isRequired,
+    createAccount: func.isRequired,
+    reset: func.isRequired,
+    user: shape({
+        isSignedIn: bool
+    })
+};
+
+Receipt.defaultProps = {
+    order: {},
+    reset: () => {},
+    createAccount: () => {}
+};
+
+export default Receipt;

--- a/packages/venia-concept/src/components/Checkout/Receipt/receipt.js
+++ b/packages/venia-concept/src/components/Checkout/Receipt/receipt.js
@@ -42,7 +42,7 @@ const Receipt = props => {
                         <hr />
                         <div className={classes.textBlock}>
                             Track order status and earn rewards for your
-                            purchase by creating and account.
+                            purchase by creating an account.
                         </div>
                         <Button priority="high" onClick={handleCreateAccount}>
                             Create an Account

--- a/packages/venia-concept/src/components/Checkout/Receipt/receipt.js
+++ b/packages/venia-concept/src/components/Checkout/Receipt/receipt.js
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect } from 'react';
+import React, { Fragment, useCallback, useEffect } from 'react';
 import { bool, func, shape, string } from 'prop-types';
 import { mergeClasses } from 'src/classify';
 import Button from 'src/components/Button';
@@ -22,57 +22,45 @@ const Receipt = props => {
         // TODO: Implement/connect/redirect to order details page.
     }, [order]);
 
-    if (user.isSignedIn) {
-        return (
-            <div className={classes.root}>
-                <div className={classes.body}>
-                    <h2 className={classes.header}>
-                        Thank you for your purchase!
-                    </h2>
-                    <div className={classes.textBlock}>
-                        You will receive an order confirmation email with order
-                        status and other details.
-                        <br />
-                        You can also visit your account page for more
-                        information.
-                    </div>
-                    <Button
-                        data-id={VIEW_ORDER_DETAILS_BUTTON_ID}
-                        onClick={handleViewOrderDetails}
-                    >
-                        View Order Details
-                    </Button>
+    return (
+        <div className={classes.root}>
+            <div className={classes.body}>
+                <h2 className={classes.header}>Thank you for your purchase!</h2>
+                <div className={classes.textBlock}>
+                    You will receive an order confirmation email with order
+                    status and other details.
                 </div>
+                {user.isSignedIn ? (
+                    <Fragment>
+                        <div className={classes.textBlock}>
+                            You can also visit your account page for more information.
+                        </div>
+                        <Button
+                            data-id={VIEW_ORDER_DETAILS_BUTTON_ID}
+                            onClick={handleViewOrderDetails}
+                        >
+                            View Order Details
+                        </Button>
+                    </Fragment>
+                ) : (
+                    <Fragment>
+                        <hr />
+                        <div className={classes.textBlock}>
+                            Track order status and earn rewards for your
+                            purchase by creating and account.
+                        </div>
+                        <Button
+                            data-id={CREATE_ACCOUNT_BUTTON_ID}
+                            priority="high"
+                            onClick={handleCreateAccount}
+                        >
+                            Create an Account
+                        </Button>
+                    </Fragment>
+                )}
             </div>
-        );
-    } else {
-        return (
-            <div className={classes.root}>
-                <div className={classes.body}>
-                    <h2 className={classes.header}>
-                        Thank you for your purchase!
-                    </h2>
-                    <div className={classes.textBlock}>
-                        You will receive an order confirmation email with order
-                        status and other details.
-                        <br />
-                    </div>
-                    <hr />
-                    <div className={classes.textBlock}>
-                        Track order status and earn rewards for your purchase by
-                        creating and account.
-                    </div>
-                    <Button
-                        data-id={CREATE_ACCOUNT_BUTTON_ID}
-                        priority="high"
-                        onClick={handleCreateAccount}
-                    >
-                        Create an Account
-                    </Button>
-                </div>
-            </div>
-        );
-    }
+        </div>
+    );
 };
 
 Receipt.propTypes = {

--- a/packages/venia-concept/src/components/Checkout/Receipt/receiptContainer.js
+++ b/packages/venia-concept/src/components/Checkout/Receipt/receiptContainer.js
@@ -1,7 +1,7 @@
 import { connect, withRouter } from 'src/drivers';
 import { compose } from 'redux';
 import actions from 'src/actions/checkoutReceipt';
-import { continueShopping, createAccount } from 'src/actions/checkout';
+import { createAccount } from 'src/actions/checkout';
 import Receipt from './receipt';
 import { getOrderInformation } from 'src/selectors/checkoutReceipt';
 
@@ -12,7 +12,6 @@ const mapStateToProps = state => ({
 });
 
 const mapDispatchToProps = {
-    continueShopping,
     createAccount,
     reset
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -8071,14 +8071,6 @@ graphql-cli-prepare@1.4.19:
     graphql-static-binding "0.9.3"
     lodash "4.17.5"
 
-graphql-cli-validate-magento-pwa-queries@~1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/graphql-cli-validate-magento-pwa-queries/-/graphql-cli-validate-magento-pwa-queries-1.0.0.tgz#d50a82007e361f10e477364ca0a9a9a4c6fc6b2a"
-  integrity sha512-BaZbZIV89C+BMDliDhz2Z58bJrbbwxGvlu636Vwiqk0KYp7PpwTu8TCBqJXz4xxxRK/wYlki8gBFlkUslI1o8Q==
-  dependencies:
-    eslint "~5.15.1"
-    eslint-plugin-graphql "~3.0.3"
-
 graphql-cli@~3.0.11:
   version "3.0.11"
   resolved "https://registry.yarnpkg.com/graphql-cli/-/graphql-cli-3.0.11.tgz#135d845c1cd7c2a2aac8be543de334543a0ff437"


### PR DESCRIPTION
## Description
1. Refactor `Receipt` to be a functional component.
1. Remove order ID text from display.
2. Add "View Order Details" button for authed users. Currently no-op as there is no order details page.
3. Update text/style to match mock.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here with the specific wording: "Closes #<issue>" -->
<!--- Using the above wording causes Github to automatically close the issue on merge. -->
Closes #816.

## Verification Steps
<!-- Please describe in detail how a reviewer can verify your changes. -->
1. As an authed user, check out and view the receipt. Should match mocks.
2. As a guest, check out and view the receipt. Should match mocks.

## How Have YOU Tested this?
Verification steps above!

## Screenshots / Screen Captures (if appropriate):

## Proposed Labels for Change Type/Package
<!--- What type of change level would you suggest for this PR? -->
<!--- Major, Minor, or Patch? -->
<!--- See https://magento-research.github.io/pwa-studio/technologies/versioning/ for help -->
- [ ] major (e.g x.0.0 - a breaking change)
- [ ] minor (e.g 0.x.0 - a backwards compatible addition)
- [x] patch (e.g 0.0.x - a bug fix)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly, if necessary.
- [ ] I have added tests to cover my changes, if necessary.
