### PR TITLE
Restrict thumbnail size in searchbar

### DIFF
--- a/packages/venia-concept/src/components/SearchBar/__tests__/__snapshots__/suggestedProduct.spec.js.snap
+++ b/packages/venia-concept/src/components/SearchBar/__tests__/__snapshots__/suggestedProduct.spec.js.snap
@@ -7,6 +7,7 @@ Array [
   >
     <img
       alt="Product Name"
+      className="thumbnail"
     />
   </span>,
   <span

--- a/packages/venia-concept/src/components/SearchBar/suggestedProduct.css
+++ b/packages/venia-concept/src/components/SearchBar/suggestedProduct.css
@@ -12,6 +12,11 @@
     justify-content: center;
 }
 
+.thumbnail {
+    max-height: 75px;
+    max-width: 60px;
+}
+
 .name {
     word-break: break-word;
 }

--- a/packages/venia-concept/src/components/SearchBar/suggestedProduct.js
+++ b/packages/venia-concept/src/components/SearchBar/suggestedProduct.js
@@ -26,7 +26,8 @@ class SuggestedProduct extends Component {
             root: string,
             image: string,
             name: string,
-            price: string
+            price: string,
+            thumbnail: string
         })
     };
 
@@ -49,6 +50,7 @@ class SuggestedProduct extends Component {
                 <span className={classes.image}>
                     <img
                         alt={name}
+                        className={classes.thumbnail}
                         src={resourceUrl(small_image, {
                             type: 'image-product',
                             width: 60


### PR DESCRIPTION
## Description

Restrict the height and width of the thumbnail images in the search bar's suggested products. Currently, the view expects image assets to be properly sized and has no CSS safeguards in the case where they are not.

## Related Issue

Closes #1250.

## Verification Steps
<!-- Please describe in detail how a reviewer can verify your changes. -->
1. Search for `athena` in the search bar.
2. Remove any query params from the URI in the thumbnail's `src` attribute.
3. Verify the presentation matches the design.

## Proposed Labels for Change Type/Package
<!--- What type of change level would you suggest for this PR? -->
<!--- Major, Minor, or Patch? -->
<!--- See https://magento-research.github.io/pwa-studio/technologies/versioning/ for help -->
- [ ] major (e.g x.0.0 - a breaking change)
- [x] minor (e.g 0.x.0 - a backwards compatible addition)
- [ ] patch (e.g 0.0.x - a bug fix)