### PR TITLE
fix(header): Remove double searchicon at load. Fixes #1273.

### DIFF
--- a/packages/venia-concept/src/components/Header/header.js
+++ b/packages/venia-concept/src/components/Header/header.js
@@ -46,7 +46,7 @@ const Header = props => {
                     <CartTrigger />
                 </div>
             </div>
-            <Suspense fallback={searchIcon}>
+            <Suspense fallback={searchOpen ? searchIcon : null}>
                 <Route
                     render={({ history, location }) => (
                         <SearchBar


### PR DESCRIPTION
## Description
In `packages/venia-concept/src/components/Header`, the SearchBar is a dynamically loaded component. We render it with `React.Suspense` and it loads in a non-blocking background call.

However, before the `SearchBar` has loaded, the `<Suspense fallback={searchIcon}>` element displays the `searchIcon`. The full `SearchBar` knows to render null if `searchOpen` is false, but the `searchIcon` does not--so until the `SearchBar` is loaded, you get two magnifying glasses, one dropping below the header to expand its height.
The fix is to put a conditional on `searchOpen` in the fallback prop as well.

## Related Issue
Closes #1273.

## Verification Steps
<!-- Please describe in detail how a reviewer can verify your changes. -->
1. Start a dev server.
2. In Chrome Developer Tools, set network throttling to Fast 3G.
3. Load any page.
4. Witness that there are never two magnifying glasses.

## How Have YOU Tested this?
Visually under several network conditions.

## Proposed Labels for Change Type/Package
<!--- What type of change level would you suggest for this PR? -->
<!--- Major, Minor, or Patch? -->
<!--- See https://magento-research.github.io/pwa-studio/technologies/versioning/ for help -->
- [ ] major (e.g x.0.0 - a breaking change)
- [ ] minor (e.g 0.x.0 - a backwards compatible addition)
- [x] patch (e.g 0.0.x - a bug fix)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly, if necessary.
- [x] I have added tests to cover my changes, if necessary.
