### PR TITLE
Tutorial page improvements

### DIFF
--- a/pwa-devdocs/src/index.html
+++ b/pwa-devdocs/src/index.html
@@ -44,10 +44,10 @@ layout: home
       </div>
 
       <div class="column">
-        <a href="{{ site.baseurl }}{% link technologies/tools-libraries/index.md %}" class="card">
-          <h2>Tools and Libraries</h2>
+        <a href="{{ site.baseurl }}{% link tutorials/index.md %}" class="card">
+          <h2>Tutorials</h2>
           <p>
-            The technologies that power Magento PWA Studio projects.
+            Become familiar with the different tools offered by the PWA Studio library.
           </p>
         </a>
       </div>

--- a/pwa-devdocs/src/tutorials/index.md
+++ b/pwa-devdocs/src/tutorials/index.md
@@ -11,17 +11,16 @@ This section contains links to tutorials that will help you become familiar with
 This three part tutorial provides an introduction to the concepts introduced in the UPWARD spec.
 By the end of this tutorial, you should have a simple React application running on top of an UPWARD server.
 
-1. [Creating a simple UPWARD server][] - Teaches the very basics of reading and writing an UPWARD specification file for your projects
-2. [Using the TemplateResolver][] - Introduces the concept of using templates and the TemplateResolver to keep your UPWARD specification file lean
-3. [Adding React][] - Add React and Webpack into your UPWARD project
+1.  [Creating a simple UPWARD server][] - Teaches the very basics of reading and writing an UPWARD specification file for your projects
+2.  [Using the TemplateResolver][] - Introduces the concept of using templates and the TemplateResolver to keep your UPWARD specification file lean
+3.  [Adding React][] - Add React and Webpack into your UPWARD project
 
 ### Magento Cloud deployment
 
 [Magento Cloud deployment][] - Provides steps for deploying a PWA Studio storefront into the Magento Cloud.
 This tutorial uses the Venia example storefront to illustrate the general process.
 
-
-[creating a simple upward server]: {{site.baseurl}}{%link tutorials/hello-upward/simple-server/index.md%}
-[using the templateresolver]: {{site.baseurl}}{%link tutorials/hello-upward/using-template-resolver/index.md%}
-[adding react]: {{site.baseurl}}{%link tutorials/hello-upward/adding-react/index.md%}
-[Magento Cloud deployment]: {{site.baseurl}}{%link tutorials/cloud-deploy/index.md %}
+[creating a simple upward server]: <{{site.baseurl}}{%link tutorials/hello-upward/simple-server/index.md%}>
+[using the templateresolver]: <{{site.baseurl}}{%link tutorials/hello-upward/using-template-resolver/index.md%}>
+[adding react]: <{{site.baseurl}}{%link tutorials/hello-upward/adding-react/index.md%}>
+[magento cloud deployment]: <{{site.baseurl}}{%link tutorials/cloud-deploy/index.md %}>

--- a/pwa-devdocs/src/tutorials/index.md
+++ b/pwa-devdocs/src/tutorials/index.md
@@ -2,4 +2,26 @@
 title: Tutorials
 ---
 
-This section contains tutorials that will help you become familiar with the different tools provided by PWA Studio.
+This section contains links to tutorials that will help you become familiar with the different tools provided by PWA Studio.
+
+## Recommended tutorials
+
+### UPWARD
+
+This three part tutorial provides an introduction to the concepts introduced in the UPWARD spec.
+By the end of this tutorial, you should have a simple React application running on top of an UPWARD server.
+
+1. [Creating a simple UPWARD server][] - Teaches the very basics of reading and writing an UPWARD specification file for your projects
+2. [Using the TemplateResolver][] - Introduces the concept of using templates and the TemplateResolver to keep your UPWARD specification file lean
+3. [Adding React][] - Add React and Webpack into your UPWARD project
+
+### Magento Cloud deployment
+
+[Magento Cloud deployment][] - Provides steps for deploying a PWA Studio storefront into the Magento Cloud.
+This tutorial uses the Venia example storefront to illustrate the general process.
+
+
+[creating a simple upward server]: {{site.baseurl}}{%link tutorials/hello-upward/simple-server/index.md%}
+[using the templateresolver]: {{site.baseurl}}{%link tutorials/hello-upward/using-template-resolver/index.md%}
+[adding react]: {{site.baseurl}}{%link tutorials/hello-upward/adding-react/index.md%}
+[Magento Cloud deployment]: {{site.baseurl}}{%link tutorials/cloud-deploy/index.md %}


### PR DESCRIPTION
## Description

Makes the Tutorial section easier to discover on the front page and add content to the Tutorial overview page.

## Related Issue

Closes #1248 

## Verification Steps
1. Navigate to the `pwa-devdocs` directory
2. Run the linter: `npm run lint src/tutorials/index.md`
3. Verify there are no linter issues listed
4. Run the preview server: `npm run develop`
5. Verify the **Tutorial** panel is displayed instead of the **Tools and Libraries** section
6. Click on the **Tutorial** panel
7. Verify the Tutorial overview page is not bare and contains links to the different tutorials

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly, if necessary.
- [ ] I have added tests to cover my changes, if necessary.
