### PR TITLE
[BUGFIX] Solved 404 links for 'Edit this page on GitHub'

### DIFF
--- a/pwa-devdocs/src/_config.yml
+++ b/pwa-devdocs/src/_config.yml
@@ -10,7 +10,7 @@ logo: PWA Docs
 github_link: true
 feedback_link: true
 github_repo: "https://github.com/magento-research/pwa-studio/"
-github_files: "https://github.com/magento-research/pwa-studio/tree/master/pwa-devdocs/src/"
+github_files: "https://github.com/magento-research/pwa-studio/tree/develop/pwa-devdocs/src/"
 
 
 defaults:


### PR DESCRIPTION


## Description
The 'Edit this page on GitHub' for the Upward Tutorial 404 page is resolved

https://magento-research.github.io/pwa-studio/tutorials/hello-upward/simple-server/

## Screenshots / Screen Captures (if appropriate):
![image](https://user-images.githubusercontent.com/6040343/58991626-02771880-87e9-11e9-86eb-a866ed5bbb21.png)

## Proposed Labels for Change Type/Package
<!--- What type of change level would you suggest for this PR? -->
<!--- Major, Minor, or Patch? -->
<!--- See https://magento-research.github.io/pwa-studio/technologies/versioning/ for help -->
- [ ] major (e.g x.0.0 - a breaking change)
- [ ] minor (e.g 0.x.0 - a backwards compatible addition)
- [ ] patch (e.g 0.0.x - a bug fix)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly, if necessary.
- [ ] I have added tests to cover my changes, if necessary.
