### PR TITLE
dev: ignore dangerfile since it is maintained in separate repo

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -7,3 +7,6 @@ storybook-dist
 esm
 # Devdocs is a separate project
 pwa-devdocs
+
+# Dangerfile is maintained in the pwa-studio-cicd repo and symlinked during build
+dangerfile.js


### PR DESCRIPTION
The dangerfile is maintained in the magento/pwa-studio-cicd repo. It is symlinked into the root pwa-studio when we run builds by the build pipeline. The build pipeline also happens to run `prettier` indiscriminantly, and does not care if something is a symlink. So if the dangerfile has lint issues it will cause failures in pull requests:

https://github.com/magento-research/pwa-studio/pull/1296#issuecomment-499336162

[![Image from Gyazo](https://i.gyazo.com/e8f511c014f0485b85c30aa5b7d9d410.png)](https://gyazo.com/e8f511c014f0485b85c30aa5b7d9d410)

Since we cannot move the dangerfile back into this repo, and I don't want to have to duplicate prettier rules inside the cicd repo, the next easiest thing to do is to just ignore the dangerfile.