### PR TITLE
[Documentation] Update compatibility file

### DIFF
--- a/magento-compatibility.js
+++ b/magento-compatibility.js
@@ -4,6 +4,6 @@
 
 // PWA Studio version -> Magento version.
 module.exports = {
-    '>2.0.0': '2.3.1',
+    '>2.0.0': '>=2.3.1',
     '2.0.0': '2.3.0'
 };


### PR DESCRIPTION
## Description

This PR updates the `release/3.0` branch with the correct compatibility information.

## Related Issue

Closes #1326 

## Verification Steps

1. Change Venia version to `3.0.0` in it's `package.json` file
2. Using a 2.3.2 instance as the `MAGENTO_BACKEND_URL`, such as the default cloud value, run `yarn build`
3. Verify validation succeeds.
4. Using a 2.3.0 instance as the `MAGENTO_BACKEND_URL`, run `yarn build`
5. Verify validation fails and contains the message:
     >This Venia store is from PWA Studio version 3.0.0.
Some components in PWA Studio version 3.0.0 send GraphQL queries that are only compatible with version >=2.3.1 of Magento 2. 
6. Navigate to the `pwa-devdocs` directory
7. Build and preview the docs: `npm run develop`
8. Navigate to `/technologies/magento-compatibility/`
9. Validate the data matches what is in the compatibility file.