### PR TITLE
[Bug] 1209 - Fixed an issue with undefined search queries

### DIFF
--- a/packages/venia-concept/src/components/SearchBar/searchBar.js
+++ b/packages/venia-concept/src/components/SearchBar/searchBar.js
@@ -30,7 +30,9 @@ const SearchBar = props => {
     // navigate on submit
     const handleSubmit = useCallback(
         ({ search_query }) => {
-            history.push(`/search.html?query=${search_query}`);
+            if (search_query != undefined && search_query.trim().length > 0) {
+                history.push(`/search.html?query=${search_query}`);
+            }
         },
         [history]
     );


### PR DESCRIPTION
## Description
When entering nothing into the search field and pressing enter the search was being submitted as undefined.
This also happens for queries containing only spaces as well.

## Related Issues
[1209](https://github.com/magento-research/pwa-studio/issues/1209)
[854](https://github.com/magento-research/pwa-studio/issues/854)
Closes #1209.

## Verification Steps
1. Enter nothing into the search field
2. Pressing enter should now not do anything
3. Also enter a space character into the search field
4. Again it should not do anything on submit
5. Enter "0 1" into the search field
6. The submit should happen and the loading spinner should not persist.

## How have YOU tested this?
1. Entered nothing into the search field
2. Pressing enter does now not do anything
3. Also entered a space character into the search field
4. Again it does not do anything on submit
5. Entered "0 1" into the search field
6. The loading spinner does not persist.

## Screenshots / Screen Captures (if appropriate):

## Proposed Labels for Change Type/Package
- [ ] major (e.g x.0.0 - a breaking change)
- [ ] minor (e.g 0.x.0 - a backwards compatible addition)
- [x] patch (e.g 0.0.x - a bug fix)

## Checklist:
- [x] I have updated the documentation accordingly, if necessary.
- [x] I have added tests to cover my changes, if necessary. (not necessary)
