### PR TITLE
1329 continue shopping empty cart button

### DIFF
--- a/packages/venia-concept/src/components/MiniCart/emptyMiniCart.css
+++ b/packages/venia-concept/src/components/MiniCart/emptyMiniCart.css
@@ -12,13 +12,3 @@
     line-height: 1.25;
     margin-bottom: 1.5rem;
 }
-
-.continue {
-    composes: root from '../Button/button.css';
-    color: white;
-    background-color: rgb(var(--venia-teal));
-}
-
-.continue:hover {
-    color: rgb(var(--venia-teal));
-}

--- a/packages/venia-concept/src/components/MiniCart/emptyMiniCart.js
+++ b/packages/venia-concept/src/components/MiniCart/emptyMiniCart.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { string, shape } from 'prop-types';
+import { func, string, shape } from 'prop-types';
 
 import classify from 'src/classify';
 import Button from 'src/components/Button';
@@ -11,18 +11,21 @@ class EmptyMiniCart extends Component {
             root: string,
             emptyTitle: string,
             continue: string
-        })
+        }),
+        closeDrawer: func
     };
 
     render() {
-        const { classes } = this.props;
+        const { classes, closeDrawer } = this.props;
 
         return (
             <div className={classes.root}>
                 <h3 className={classes.emptyTitle}>
                     There are no items in your shopping cart
                 </h3>
-                <Button priority="high">Continue Shopping</Button>
+                <Button priority="high" onClick={closeDrawer}>
+                    Continue Shopping
+                </Button>
             </div>
         );
     }

--- a/packages/venia-concept/src/components/MiniCart/emptyMiniCart.js
+++ b/packages/venia-concept/src/components/MiniCart/emptyMiniCart.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import { string, shape } from 'prop-types';
 
 import classify from 'src/classify';
-import Trigger from './trigger';
+import Button from 'src/components/Button';
 import defaultClasses from './emptyMiniCart.css';
 
 class EmptyMiniCart extends Component {
@@ -22,9 +22,7 @@ class EmptyMiniCart extends Component {
                 <h3 className={classes.emptyTitle}>
                     There are no items in your shopping cart
                 </h3>
-                <Trigger>
-                    <span className={classes.continue}>Continue Shopping</span>
-                </Trigger>
+                <Button priority="high">Continue Shopping</Button>
             </div>
         );
     }

--- a/packages/venia-concept/src/components/MiniCart/miniCart.js
+++ b/packages/venia-concept/src/components/MiniCart/miniCart.js
@@ -4,6 +4,7 @@ import { connect } from 'src/drivers';
 import { bool, func, object, shape, string } from 'prop-types';
 import { Price } from '@magento/peregrine';
 import classify from 'src/classify';
+import { closeDrawer } from 'src/actions/app';
 import {
     getCartDetails,
     updateItemInCart,
@@ -57,7 +58,8 @@ class MiniCart extends Component {
         updateItemInCart: func,
         openOptionsDrawer: func.isRequired,
         closeOptionsDrawer: func.isRequired,
-        isMiniCartMaskOpen: bool
+        isMiniCartMaskOpen: bool,
+        closeDrawer: func
     };
 
     constructor(...args) {
@@ -212,10 +214,10 @@ class MiniCart extends Component {
 
     get miniCartInner() {
         const { checkout, productList, props } = this;
-        const { classes, isCartEmpty, isMiniCartMaskOpen } = props;
+        const { classes, isCartEmpty, isMiniCartMaskOpen, closeDrawer } = props;
 
         if (isCartEmpty) {
-            return <EmptyMiniCart />;
+            return <EmptyMiniCart closeDrawer={closeDrawer} />;
         }
 
         const footer = checkout;
@@ -279,7 +281,8 @@ const mapDispatchToProps = {
     removeItemFromCart,
     openOptionsDrawer,
     closeOptionsDrawer,
-    cancelCheckout
+    cancelCheckout,
+    closeDrawer
 };
 
 export default compose(


### PR DESCRIPTION
## Description
Fixes styles for the mini cart empty cart 'Continue Shopping' button and refactors the code to handle closure of the drawer by moving functionality up into the main mini cart component.

The 'Continue Shopping' button element has been refactored to use the same component as the 'Sign In' / 'Create Account' buttons in the left hand drawer for consistency.

## Related Issue
Closes # .

## Verification Steps
1. Go to the homepage.
2. Open the minicart (ensure no products are in your cart)
3. The 'Continue Shopping' button should be visible
4. The styles for the 'Continue Shopping' button should be as described in the issue
5. Clicking the 'Continue Shopping' button should close the mini cart drawer

## How have YOU tested this?
By following the verification steps

## Screenshots / Screen Captures (if appropriate):

## Proposed Labels for Change Type/Package
- [ ] major (e.g x.0.0 - a breaking change)
- [ ] minor (e.g 0.x.0 - a backwards compatible addition)
- [x] patch (e.g 0.0.x - a bug fix)

## Checklist:
- [x] I have updated the documentation accordingly, if necessary.
- [x] I have added tests to cover my changes, if necessary.