### PR TITLE
Feature/1284 user hovering toasts

### DIFF
--- a/packages/peregrine/src/Toasts/useToastContext.js
+++ b/packages/peregrine/src/Toasts/useToastContext.js
@@ -54,6 +54,24 @@ const reducer = (prevState = initialState, action = {}) => {
                 toasts: nextToasts
             };
         }
+        case 'pause' : {
+            const nextToasts = new Map(prevState.toasts);
+            nextToasts.forEach((toast) => {
+                toast.pauseToast();
+            })
+            return {
+                ...prevState
+            }
+        }
+        case 'unpause' : {
+            const nextToasts = new Map(prevState.toasts);
+            nextToasts.forEach((toast) => {
+                toast.unpauseToast();
+            })
+            return {
+                ...prevState
+            }
+        }
         default:
             return prevState;
     }

--- a/packages/peregrine/src/Toasts/useToastContext.js
+++ b/packages/peregrine/src/Toasts/useToastContext.js
@@ -54,23 +54,23 @@ const reducer = (prevState = initialState, action = {}) => {
                 toasts: nextToasts
             };
         }
-        case 'pause' : {
+        case 'pause': {
             const nextToasts = new Map(prevState.toasts);
-            nextToasts.forEach((toast) => {
+            nextToasts.forEach(toast => {
                 toast.pauseToast();
-            })
+            });
             return {
                 ...prevState
-            }
+            };
         }
-        case 'unpause' : {
+        case 'unpause': {
             const nextToasts = new Map(prevState.toasts);
-            nextToasts.forEach((toast) => {
+            nextToasts.forEach(toast => {
                 toast.unpauseToast();
-            })
+            });
             return {
                 ...prevState
-            }
+            };
         }
         default:
             return prevState;

--- a/packages/peregrine/src/Toasts/useToasts.js
+++ b/packages/peregrine/src/Toasts/useToasts.js
@@ -117,15 +117,14 @@ export const useToasts = () => {
             const handleAction = () =>
                 onAction ? onAction(() => removeToast(id)) : () => {};
 
-
             const pauseToast = () => {
                 allowToastToDie = false;
-            }
+            };
 
             const unpauseToast = () => {
                 allowToastToDie = true;
                 setNewTimeout();
-            }
+            };
 
             let removalTimeoutId;
             const setNewTimeout = () => {
@@ -133,13 +132,12 @@ export const useToasts = () => {
                 if (timeout !== 0 && timeout !== false) {
                     removalTimeoutId = setTimeout(
                         () => {
-                            if (allowToastToDie)
-                                handleDismiss();
+                            if (allowToastToDie) handleDismiss();
                         },
                         timeout ? timeout : DEFAULT_TIMEOUT
                     );
                 }
-            }
+            };
             setNewTimeout();
 
             dispatch({
@@ -180,14 +178,14 @@ export const useToasts = () => {
         dispatch({
             type: 'pause',
             payload: {}
-        })
-    }
+        });
+    };
     const unpauseAllToasts = () => {
         dispatch({
             type: 'unpause',
             payload: {}
-        })
-    }
+        });
+    };
 
     /**
      * @typedef ToastApi

--- a/packages/venia-concept/src/components/ToastContainer/toastContainer.js
+++ b/packages/venia-concept/src/components/ToastContainer/toastContainer.js
@@ -23,10 +23,10 @@ const ToastContainer = props => {
         });
 
     return (
-        <div 
-            id="toast-root" 
+        <div
+            id="toast-root"
             className={classes.root}
-            onMouseEnter={api.pauseAllToasts} 
+            onMouseEnter={api.pauseAllToasts}
             onMouseLeave={api.unpauseAllToasts}
         >
             {toastElements}

--- a/packages/venia-concept/src/components/ToastContainer/toastContainer.js
+++ b/packages/venia-concept/src/components/ToastContainer/toastContainer.js
@@ -7,7 +7,7 @@ import defaultClasses from './toastContainer.css';
 
 const ToastContainer = props => {
     const classes = mergeClasses(defaultClasses, props.classes);
-    const [{ toasts }] = useToasts();
+    const [{ toasts }, api] = useToasts();
 
     // Given a map of toasts each with a property "timestamp", sort and display
     // based on the timestamp.
@@ -23,7 +23,12 @@ const ToastContainer = props => {
         });
 
     return (
-        <div id="toast-root" className={classes.root}>
+        <div 
+            id="toast-root" 
+            className={classes.root}
+            onMouseEnter={api.pauseAllToasts} 
+            onMouseLeave={api.unpauseAllToasts}
+        >
             {toastElements}
         </div>
     );


### PR DESCRIPTION
<!--
Before submitting this pull request, please make sure you have read our Contribution Guidelines and your PR meets our contribution standards:
https://github.com/magento-research/pwa-studio/blob/master/.github/CONTRIBUTING.md

Please fill out as much information as you can about your PR to help speed up the review process.
If your PR addresses an existing GitHub Issue, please refer to it in the title or Additional Information section to make the connection.

We may ask you for changes in your PR in order to meet the standards set in our Contribution Guidelines. PRs that do not comply with our guidelines may be closed at the maintainers' discretion.

Feel free to remove this section before creating this PR. Thank you for your contribution!
-->

## Description
Toasts now do not timeout when the user hovers over the container of the toasts, allowing them to copy text if needed etc.
The timeout then resumes if the user moves out of the toast container

## Related Issue
Closes #[1284](https://github.com/magento-research/pwa-studio/issues/1284).

## Verification Steps
1. Run venia storybook and go to existing story "Non-dismissable toasts that timeout"
2. Hover over the toast and see it should remain
3. Hover outside of all the toasts and see it should fade as expected

## How have YOU tested this?
1. Ran venia storybook with existing story "Non-dismissable toasts that timeout"
2. Hovered over a toast and saw it remain
3. Hovered outside of all the toasts and saw it fade as expected

## Screenshots / Screen Captures (if appropriate):

## Proposed Labels for Change Type/Package
- [ ] major (e.g x.0.0 - a breaking change)
- [ ] minor (e.g 0.x.0 - a backwards compatible addition)
- [x] patch (e.g 0.0.x - a bug fix)

## Checklist:
- [x] I have updated the documentation accordingly, if necessary.
- [x] I have added tests to cover my changes, if necessary.
