### PR TITLE
bug Add name for search trigger button

### DIFF
--- a/packages/venia-concept/src/components/Header/searchTrigger.js
+++ b/packages/venia-concept/src/components/Header/searchTrigger.js
@@ -21,7 +21,7 @@ class SearchTrigger extends Component {
 
         return (
             <Fragment>
-                <button className={searchClass} onClick={toggleSearch}>
+                <button className={searchClass} name="button" onClick={toggleSearch}>
                     {children}
                 </button>
             </Fragment>

--- a/packages/venia-concept/src/components/Header/searchTrigger.js
+++ b/packages/venia-concept/src/components/Header/searchTrigger.js
@@ -23,7 +23,7 @@ class SearchTrigger extends Component {
             <Fragment>
                 <button
                     className={searchClass}
-                    name="button"
+                    role="button"
                     onClick={toggleSearch}
                 >
                     {children}

--- a/packages/venia-concept/src/components/Header/searchTrigger.js
+++ b/packages/venia-concept/src/components/Header/searchTrigger.js
@@ -21,7 +21,11 @@ class SearchTrigger extends Component {
 
         return (
             <Fragment>
-                <button className={searchClass} name="button" onClick={toggleSearch}>
+                <button
+                    className={searchClass}
+                    name="button"
+                    onClick={toggleSearch}
+                >
                     {children}
                 </button>
             </Fragment>

--- a/packages/venia-concept/src/components/Header/searchTrigger.js
+++ b/packages/venia-concept/src/components/Header/searchTrigger.js
@@ -23,7 +23,7 @@ class SearchTrigger extends Component {
             <Fragment>
                 <button
                     className={searchClass}
-                    role="button"
+                    aria-label={'Search'}
                     onClick={toggleSearch}
                 >
                     {children}


### PR DESCRIPTION
## Description

Add name property for search button on searchTrigger component  to increase Accessibility score in Lighthouse.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here by replacing ISSUE_NUMBER with your actual issue number. -->
<!--- Using the above wording causes Github to automatically close the issue on merge. -->
Closes #1386

## Verification Steps
<!-- Please describe in detail how a reviewer can verify your changes. -->
1. Run Lighthouse on https://magento-venia-develop.now.sh
2. Scroll down to the Accessibility section.
3. Don't see any warning about like ""Buttons do not have an accessible name""

## Screenshots / Screen Captures (if appropriate)

## Proposed Labels for Change Type/Package

## Checklist:
Verification steps above!