### PR TITLE
No such file or directory creating .env file

### DIFF
--- a/packages/pwa-buildpack/bin/buildpack
+++ b/packages/pwa-buildpack/bin/buildpack
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 require('yargs')
-    .commandDir('../dist/cli')
+    .commandDir('../src/cli')
     .demandCommand(
         1,
         'Invoke buildpack with a subcommand (eg. `buildpack create-env-file`) and the arguments to that subcommand.'


### PR DESCRIPTION
<!--
Before submitting this pull request, please make sure you have read our Contribution Guidelines and your PR meets our contribution standards:
https://github.com/magento-research/pwa-studio/blob/master/.github/CONTRIBUTING.md

Please fill out as much information as you can about your PR to help speed up the review process.
If your PR addresses an existing GitHub Issue, please refer to it in the title or Additional Information section to make the connection.

We may ask you for changes in your PR in order to meet the standards set in our Contribution Guidelines. PRs that do not comply with our guidelines may be closed at the maintainers' discretion.

Feel free to remove this section before creating this PR. Thank you for your contribution!
-->

## Description

#1414 Running the command `yarn buildpack create-env-file packages/venia-concept` to generate the .env file throws an error.

## Expected
```
$ yarn buildpack create-env-file packages/venia-concept
yarn run v1.16.0
$ /Users/jondoe/Sites/pwa-studio/node_modules/.bin/buildpack create-env-file packages/venia-concept
  ⓧ  Missing required environment variables:
     MAGENTO_BACKEND_URL: Connect to an instance of Magento 2.3 by specifying its public domain name. (eg.
     "https://master-7rqtwti-mfwmkrjfqvbjk.us-4.magentosite.cloud/")
  ⚠  The current environment is not yet valid; please set any missing variables to build the project before generating a .env file.
  ℹ  Successfully wrote a fresh configuration file to /Users/jondoe/Sites/pwa-studio/packages/venia-concept/.env
✨  Done in 0.41s.
```
## Actual
```
yarn run v1.16.0
$ /Users/jondoe/Sites/pwa-studio/node_modules/.bin/buildpack create-env-file packages/venia-concept
fs.js:114
    throw err;
    ^

Error: ENOENT: no such file or directory, scandir '/Users/jondoe/Sites/pwa-studio/packages/pwa-buildpack/dist/cli'
    at Object.readdirSync (fs.js:790:3)
    at requireDirectory (/Users/jondoe/Sites/pwa-studio/node_modules/require-directory/index.js:59:6)
    at Object.addDirectory (/Users/jondoe/Sites/pwa-studio/packages/pwa-buildpack/node_modules/yargs/lib/command.js:112:33)
    at Object.Yargs.self.commandDir (/Users/jondoe/Sites/pwa-studio/packages/pwa-buildpack/node_modules/yargs/yargs.js:364:13)
    at Object.<anonymous> (/Users/jondoe/Sites/pwa-studio/packages/pwa-buildpack/bin/buildpack:4:6)
    at Module._compile (internal/modules/cjs/loader.js:776:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:787:10)
    at Module.load (internal/modules/cjs/loader.js:653:32)
    at tryModuleLoad (internal/modules/cjs/loader.js:593:12)
    at Function.Module._load (internal/modules/cjs/loader.js:585:3)
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here by replacing ISSUE_NUMBER with your actual issue number. -->
<!--- Using the above wording causes Github to automatically close the issue on merge. -->
Closes #1414 
## Verification Steps
<!-- Please describe in detail how a reviewer can verify your changes. -->
1. Run the command `yarn buildpack create-env-file packages/venia-concept`
## Screenshots / Screen Captures (if appropriate)

## Proposed Labels for Change Type/Package
<!--- What type of change level would you suggest for this PR? -->
<!--- Major, Minor, or Patch? -->
<!--- See https://magento-research.github.io/pwa-studio/technologies/versioning/ for help -->
- [ ] major (e.g x.0.0 - a breaking change)
- [ ] minor (e.g 0.x.0 - a backwards compatible addition)
- [x] patch (e.g 0.0.x - a bug fix)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly, if necessary.
- [ ] I have added tests to cover my changes, if necessary.
