### PR TITLE
[bug]: Lazy load braintree dropin

### DIFF
--- a/packages/venia-concept/src/components/Checkout/__tests__/__snapshots__/braintreeDropin.spec.js.snap
+++ b/packages/venia-concept/src/components/Checkout/__tests__/__snapshots__/braintreeDropin.spec.js.snap
@@ -1,9 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`renders an error if isError state is true 1`] = `
-<span
-  className="error"
+<div
+  className="root"
 >
-  There was an error loading payment options. Please try again later.
-</span>
+  <div
+    id="braintree-dropin-container"
+  />
+</div>
 `;

--- a/packages/venia-concept/src/components/Checkout/braintreeDropin.js
+++ b/packages/venia-concept/src/components/Checkout/braintreeDropin.js
@@ -39,7 +39,9 @@ const BraintreeDropin = props => {
         let didClose = false;
         async function createDropinInstance() {
             try {
-                const { default: dropIn } = await import('braintree-web-drop-in');
+                const {
+                    default: dropIn
+                } = await import('braintree-web-drop-in');
                 const dropinInstance = await dropIn.create({
                     authorization,
                     container: `#${CONTAINER_ID}`,

--- a/packages/venia-concept/src/components/Checkout/braintreeDropin.js
+++ b/packages/venia-concept/src/components/Checkout/braintreeDropin.js
@@ -16,7 +16,6 @@ import { Util } from '@magento/peregrine';
 
 import defaultClasses from './braintreeDropin.css';
 import { mergeClasses } from 'src/classify';
-import dropIn from 'braintree-web-drop-in';
 
 const { BrowserPersistence } = Util;
 const storage = new BrowserPersistence();
@@ -40,6 +39,7 @@ const BraintreeDropin = props => {
         let didClose = false;
         async function createDropinInstance() {
             try {
+                const { default: dropIn } = await import('braintree-web-drop-in');
                 const dropinInstance = await dropIn.create({
                     authorization,
                     container: `#${CONTAINER_ID}`,


### PR DESCRIPTION
## Description

See issue.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here by replacing ISSUE_NUMBER with your actual issue number. -->
<!--- Using the above wording causes Github to automatically close the issue on merge. -->
Closes #1418 .

## Verification Steps
<!-- Please describe in detail how a reviewer can verify your changes. -->
1. Run `yarn install` and `cd packages/venia-concept` and `yarn build:analyze`.
2. The output should show braintree dropin in a chunk rather than the client bundle.

## Screenshots / Screen Captures (if appropriate)
[![Image from Gyazo](https://i.gyazo.com/806d426f636dcc4f27b6dfb1bbe86e6c.png)](https://gyazo.com/806d426f636dcc4f27b6dfb1bbe86e6c)

## Proposed Labels for Change Type/Package
<!--- What type of change level would you suggest for this PR? -->
<!--- Major, Minor, or Patch? -->
<!--- See https://magento-research.github.io/pwa-studio/technologies/versioning/ for help -->
- [ ] major (e.g x.0.0 - a breaking change)
- [ ] minor (e.g 0.x.0 - a backwards compatible addition)
- [x] patch (e.g 0.0.x - a bug fix)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly, if necessary.
- [ ] I have added tests to cover my changes, if necessary.
