### PR TITLE
Refactor create-account route to use appShell to get provided requisite properties

### DIFF
--- a/packages/venia-concept/src/util/makeUrl.js
+++ b/packages/venia-concept/src/util/makeUrl.js
@@ -1,8 +1,9 @@
 // If the root template supplies the backend URL at runtime, use it directly
-const {
-    imageOptimizingOrigin,
-    mediaBackend = 'https://backend.test/media/'
-} = document.querySelector('html').dataset;
+const htmlDataset = document.querySelector('html').dataset;
+const { imageOptimizingOrigin } = htmlDataset;
+// Protect against potential falsy values for `mediaBackend`.
+const mediaBackend = htmlDataset.mediaBackend || 'https://backend.test/media/';
+
 const useBackendForImgs = imageOptimizingOrigin === 'backend';
 
 // Tests if a URL begins with `http:` or `https:` or `data:`

--- a/packages/venia-concept/src/util/makeUrl.js
+++ b/packages/venia-concept/src/util/makeUrl.js
@@ -2,7 +2,11 @@
 const htmlDataset = document.querySelector('html').dataset;
 const { imageOptimizingOrigin } = htmlDataset;
 // Protect against potential falsy values for `mediaBackend`.
-const mediaBackend = htmlDataset.mediaBackend || 'https://backend.test/media/';
+let mediaBackend = htmlDataset.mediaBackend;
+if (!mediaBackend) {
+    console.warn('A media backend URL should be defined in your config.');
+    mediaBackend = 'https://backend.test/media/';
+}
 
 const useBackendForImgs = imageOptimizingOrigin === 'backend';
 

--- a/packages/venia-concept/upward.yml
+++ b/packages/venia-concept/upward.yml
@@ -356,6 +356,7 @@ index:
       engine: mustache
       template: './templates/generic-shell.mst'
       provide:
+        assets: assetManifest
         isDevelopment: isDevelopment
 
 # The static object is a DirectoryResolver that allows access to the files

--- a/packages/venia-concept/upward.yml
+++ b/packages/venia-concept/upward.yml
@@ -33,11 +33,10 @@ response:
     - matches: request.url.pathname
       pattern: '^/(graphql|rest)(/|$)'
       use: proxy
-    # Requests to create an account are handled by the top-level 'index'
-    # object, which returns a generic app shell
+    # Requests to create an account are handled by the 'appShell' object.
     - matches: request.url.pathname
       pattern: '^/create-account'
-      use: index
+      use: appShell
     # Requests for static resources provided by the application project, such
     # as icons, manifests, and static images, are handled by the top-level
     # 'static' object, which defines a DirectoryResolver that serves assets
@@ -62,18 +61,6 @@ response:
   # request is the top-level 'bundles' object, which is a DirectoryResolver that
   # serves the Webpack output assets from the './dist' folder.
   default: bundles
-
-# An object that returns true if the NODE_ENV environment variable is set
-# to 'development'. Used as a test in other configurations in this file.
-# Returns false otherwise.
-isDevelopment:
-  when:
-    - matches: env.NODE_ENV
-      pattern: 'development'
-      use:
-        inline: true
-  default:
-    inline: false
 
 # A ProxyResolver object that passes a request to the backend Magento
 # server defined in the MAGENTO_BACKEND_URL environment variable.
@@ -198,6 +185,15 @@ resource:
         inline:
           entityTypeName:
             inline: "Search Results"
+          template: './templates/generic-shell.mst'
+    - matches: request.url.pathname
+      pattern: '/create-account'
+      use:
+        inline:
+          model: createAccountModel
+          name: createAccountModel.title
+          entityTypeName:
+            inline: "Create Account"
           template: './templates/generic-shell.mst'
   default:
     # If none of the resolver conditions pass, no 'model' property is set and
@@ -344,20 +340,12 @@ bundles:
   directory:
     inline: './dist'
 
-# The index object contains response data for rendering a generic app shell
-index:
+# The createAccountModel object contains a single 'title' property that is used
+# in the template file as the page title.
+createAccountModel:
   inline:
-    status: 200
-    headers:
-      inline:
-        content-type:
-          inline: text/html
-    body:
-      engine: mustache
-      template: './templates/generic-shell.mst'
-      provide:
-        assets: assetManifest
-        isDevelopment: isDevelopment
+    title:
+      inline: 'Create Account'
 
 # The static object is a DirectoryResolver that allows access to the files
 # inside the project's './static' directory.

--- a/packages/venia-concept/upward.yml
+++ b/packages/venia-concept/upward.yml
@@ -128,6 +128,26 @@ appShell:
 # the page type based on the request URL.
 resource:
   when:
+    # This entry makes '/search.html' a valid resource path. It uses a simple
+    # inline object as its resolve data and uses the generic shell as its
+    # template file.
+    - matches: request.url.pathname
+      pattern: '/search.html'
+      use:
+        inline:
+          entityTypeName:
+            inline: "Search Results"
+          template: './templates/generic-shell.mst'
+    # This entry makes '/create-account' a valid resource path.
+    - matches: request.url.pathname
+      pattern: '/create-account'
+      use:
+        inline:
+          model: createAccountModel
+          name: createAccountModel.title
+          entityTypeName:
+            inline: "Create Account Page"
+          template: './templates/generic-shell.mst'
     # As with all other context values, `urlResolver` begins resolving the first
     # time its value is requested. If UPWARD has not yet queried the GraphQL
     # service before evaluating this match clause, then it does so now.
@@ -175,25 +195,6 @@ resource:
           name: unknownPageType.title
           entityTypeName:
             inline: "Page"
-          template: './templates/generic-shell.mst'
-    # This entry makes '/search.html' a valid resource path. It uses a simple
-    # inline object as its resolve data and uses the generic shell as its
-    # template file.
-    - matches: request.url.pathname
-      pattern: '/search.html'
-      use:
-        inline:
-          entityTypeName:
-            inline: "Search Results"
-          template: './templates/generic-shell.mst'
-    - matches: request.url.pathname
-      pattern: '/create-account'
-      use:
-        inline:
-          model: createAccountModel
-          name: createAccountModel.title
-          entityTypeName:
-            inline: "Create Account Page"
           template: './templates/generic-shell.mst'
   default:
     # If none of the resolver conditions pass, no 'model' property is set and

--- a/packages/venia-concept/upward.yml
+++ b/packages/venia-concept/upward.yml
@@ -193,7 +193,7 @@ resource:
           model: createAccountModel
           name: createAccountModel.title
           entityTypeName:
-            inline: "Create Account"
+            inline: "Create Account Page"
           template: './templates/generic-shell.mst'
   default:
     # If none of the resolver conditions pass, no 'model' property is set and


### PR DESCRIPTION

## Description

The create-account page (and probably other pages) was broken. Upward used `index` when serving `/create-account`. `index` uses generic-shell.mst, which uses default-initial-contents.st, which references `assets.svg.logo`. This means that anything using default-initial-contents.mst must also include the asset manifest.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here by replacing ISSUE_NUMBER with your actual issue number. -->
<!--- Using the above wording causes Github to automatically close the issue on merge. -->
Closes #1429.

## Verification Steps
<!-- Please describe in detail how a reviewer can verify your changes. -->
1. Run this PR locally and go to `<url>/create-account`. It should show the create account page.

## Screenshots / Screen Captures (if appropriate)
[![Image from Gyazo](https://i.gyazo.com/7ef3f450a48660adaa2f42780a7fe762.gif)](https://gyazo.com/7ef3f450a48660adaa2f42780a7fe762)

## Proposed Labels for Change Type/Package
<!--- What type of change level would you suggest for this PR? -->
<!--- Major, Minor, or Patch? -->
<!--- See https://magento-research.github.io/pwa-studio/technologies/versioning/ for help -->
- [ ] major (e.g x.0.0 - a breaking change)
- [ ] minor (e.g 0.x.0 - a backwards compatible addition)
- [x] patch (e.g 0.0.x - a bug fix)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly, if necessary.
- [ ] I have added tests to cover my changes, if necessary.
