### PR TITLE
Improve scroll locking

### DIFF
--- a/packages/peregrine/lib/hooks/useScrollLock.js
+++ b/packages/peregrine/lib/hooks/useScrollLock.js
@@ -1,0 +1,16 @@
+import { useLayoutEffect } from 'react';
+
+/**
+ * A [React Hook]{@link https://reactjs.org/docs/hooks-intro.html} that sets
+ * an attribute on the document element indicating that scrolling should be
+ * locked. This is performed with a layout effect (before paint).
+ *
+ * @kind function
+ *
+ * @param {Boolean} locked Whether scrolling should be locked.
+ */
+export const useScrollLock = locked => {
+    useLayoutEffect(() => {
+        document.documentElement.dataset.scrollLock = locked || '';
+    }, [locked]);
+};

--- a/packages/peregrine/lib/index.js
+++ b/packages/peregrine/lib/index.js
@@ -11,6 +11,7 @@ export { useQuery } from './hooks/useQuery';
 export { useQueryResult } from './hooks/useQueryResult';
 export { useRestApi } from './hooks/useRestApi';
 export { useRestResponse } from './hooks/useRestResponse';
+export { useScrollLock } from './hooks/useScrollLock';
 export { useSearchParam } from './hooks/useSearchParam';
 export {
     WindowSizeContextProvider,

--- a/packages/venia-concept/src/components/Checkbox/checkbox.css
+++ b/packages/venia-concept/src/components/Checkbox/checkbox.css
@@ -24,6 +24,7 @@
 }
 
 .input {
+    background: none;
     border: 1px solid rgb(var(--venia-text));
     border-radius: 2px;
     display: inline-flex;

--- a/packages/venia-concept/src/components/Checkout/__tests__/__snapshots__/cart.spec.js.snap
+++ b/packages/venia-concept/src/components/Checkout/__tests__/__snapshots__/cart.spec.js.snap
@@ -4,50 +4,46 @@ exports[`renders a Cart component 1`] = `
 <div
   className="root"
 >
-  <div
-    className="footer"
+  <button
+    className="root_highPriority"
+    disabled={false}
+    onClick={[MockFunction]}
+    type="button"
   >
-    <button
-      className="root_highPriority"
-      disabled={false}
-      onClick={[MockFunction]}
-      type="button"
+    <span
+      className="content"
     >
       <span
-        className="content"
+        className="root"
       >
-        <span
-          className="root"
+        <svg
+          fill="none"
+          height={16}
+          stroke="currentColor"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth="2"
+          viewBox="0 0 24 24"
+          width={16}
+          xmlns="http://www.w3.org/2000/svg"
         >
-          <svg
-            fill="none"
-            height={16}
-            stroke="currentColor"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            strokeWidth="2"
-            viewBox="0 0 24 24"
-            width={16}
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <rect
-              height="11"
-              rx="2"
-              ry="2"
-              width="18"
-              x="3"
-              y="11"
-            />
-            <path
-              d="M7 11V7a5 5 0 0 1 10 0v4"
-            />
-          </svg>
-        </span>
-        <span>
-          Checkout
-        </span>
+          <rect
+            height="11"
+            rx="2"
+            ry="2"
+            width="18"
+            x="3"
+            y="11"
+          />
+          <path
+            d="M7 11V7a5 5 0 0 1 10 0v4"
+          />
+        </svg>
       </span>
-    </button>
-  </div>
+      <span>
+        Checkout
+      </span>
+    </span>
+  </button>
 </div>
 `;

--- a/packages/venia-concept/src/components/Checkout/__tests__/__snapshots__/paymentsForm.spec.js.snap
+++ b/packages/venia-concept/src/components/Checkout/__tests__/__snapshots__/paymentsForm.spec.js.snap
@@ -501,6 +501,7 @@ exports[`renders billing address fields if addresses_same checkbox unchecked 1`]
         />
       </div>
     </div>
+    <span />
   </div>
   <div
     className="footer"

--- a/packages/venia-concept/src/components/Checkout/addressForm.css
+++ b/packages/venia-concept/src/components/Checkout/addressForm.css
@@ -16,7 +16,7 @@
     font-weight: 600;
     grid-column-end: span 2;
     line-height: 1rem;
-    padding: 0.75rem 0;
+    padding: 1.5rem 0 1.25rem;
     text-align: center;
     text-transform: uppercase;
 }

--- a/packages/venia-concept/src/components/Checkout/addressForm.css
+++ b/packages/venia-concept/src/components/Checkout/addressForm.css
@@ -1,24 +1,16 @@
 .root {
 }
 
+.heading {
+    composes: heading from './flow.css';
+}
+
 .body {
-    composes: body from './form.css';
-    grid-gap: 0.5rem;
-    padding: 0 1.5rem;
+    composes: body from './flow.css';
 }
 
 .footer {
-    composes: footer from './form.css';
-}
-
-.heading {
-    font-size: 0.875rem;
-    font-weight: 600;
-    grid-column-end: span 2;
-    line-height: 1rem;
-    padding: 1.5rem 0 1.25rem;
-    text-align: center;
-    text-transform: uppercase;
+    composes: footer from './flow.css';
 }
 
 /* fields */

--- a/packages/venia-concept/src/components/Checkout/cart.js
+++ b/packages/venia-concept/src/components/Checkout/cart.js
@@ -13,9 +13,7 @@ const Cart = props => {
 
     return (
         <div className={classes.root}>
-            <div className={classes.footer}>
-                <CheckoutButton disabled={disabled} onClick={beginCheckout} />
-            </div>
+            <CheckoutButton disabled={disabled} onClick={beginCheckout} />
         </div>
     );
 };

--- a/packages/venia-concept/src/components/Checkout/flow.css
+++ b/packages/venia-concept/src/components/Checkout/flow.css
@@ -1,5 +1,4 @@
 .root {
-    --flow-footer-height: 5.5rem;
     position: relative;
 }
 
@@ -8,7 +7,7 @@
     animation-iteration-count: 1;
     animation-name: enter;
     background-color: white;
-    bottom: var(--flow-footer-height);
+    bottom: 5rem;
     box-shadow: 0 -1px rgb(var(--venia-border));
     display: grid;
     left: 0;
@@ -23,11 +22,9 @@
     grid-auto-columns: min-content;
     grid-auto-flow: column;
     grid-gap: 0.75rem;
-    height: var(--flow-footer-height);
+    height: 5rem;
     justify-content: center;
     justify-items: center;
-    margin: 0 1.5rem;
-    padding: 1.5rem 0 1rem;
     position: relative;
 }
 

--- a/packages/venia-concept/src/components/Checkout/flow.css
+++ b/packages/venia-concept/src/components/Checkout/flow.css
@@ -2,7 +2,21 @@
     position: relative;
 }
 
+.heading {
+    background-color: white;
+    font-size: 0.875rem;
+    font-weight: 600;
+    grid-column-end: span 2;
+    line-height: 1rem;
+    padding: 1.5rem 0 1.25rem;
+    text-align: center;
+    text-transform: uppercase;
+    top: 0;
+    z-index: 1;
+}
+
 .body {
+    align-content: start;
     animation-duration: 224ms;
     animation-iteration-count: 1;
     animation-name: enter;
@@ -10,7 +24,10 @@
     bottom: 5rem;
     box-shadow: 0 -1px rgb(var(--venia-border));
     display: grid;
+    grid-gap: 0.5rem;
     left: 0;
+    overflow: auto;
+    padding: 0 1.5rem;
     position: absolute;
     right: 0;
 }

--- a/packages/venia-concept/src/components/Checkout/flow.css
+++ b/packages/venia-concept/src/components/Checkout/flow.css
@@ -26,6 +26,7 @@
     display: grid;
     grid-gap: 0.5rem;
     left: 0;
+    max-height: calc(100vh - 8.5rem);
     overflow: auto;
     padding: 0 1.5rem;
     position: absolute;

--- a/packages/venia-concept/src/components/Checkout/form.css
+++ b/packages/venia-concept/src/components/Checkout/form.css
@@ -3,6 +3,8 @@
 
 .body {
     composes: body from './flow.css';
+    grid-gap: 0;
+    padding: 0;
 }
 
 .footer {

--- a/packages/venia-concept/src/components/Checkout/paymentsForm.css
+++ b/packages/venia-concept/src/components/Checkout/paymentsForm.css
@@ -1,31 +1,17 @@
 .root {
 }
 
+.heading {
+    composes: heading from './flow.css';
+}
+
 .body {
-    composes: body from './form.css';
-    align-content: start;
-    background-color: white;
-    grid-gap: 0.5rem;
+    composes: body from './flow.css';
     height: 30rem;
-    overflow: auto;
-    padding: 0 1.5rem;
 }
 
 .footer {
-    composes: footer from './form.css';
-}
-
-.heading {
-    background-color: white;
-    font-size: 0.875rem;
-    font-weight: 600;
-    grid-column-end: span 2;
-    line-height: 1rem;
-    padding: 1.5rem 0 1.25rem;
-    text-align: center;
-    text-transform: uppercase;
-    top: 0;
-    z-index: 1;
+    composes: footer from './flow.css';
 }
 
 .button {

--- a/packages/venia-concept/src/components/Checkout/paymentsForm.css
+++ b/packages/venia-concept/src/components/Checkout/paymentsForm.css
@@ -3,14 +3,12 @@
 
 .body {
     composes: body from './form.css';
+    align-content: start;
+    background-color: white;
     grid-gap: 0.5rem;
-    height: calc(
-        var(--minicart-height) - var(--flow-footer-height) -
-            var(--minicart-footer-padding-bottom)
-    );
-    overflow-y: scroll;
+    height: 30rem;
+    overflow: auto;
     padding: 0 1.5rem;
-    grid-auto-rows: max-content;
 }
 
 .footer {
@@ -18,13 +16,17 @@
 }
 
 .heading {
+    background-color: white;
     font-size: 0.875rem;
     font-weight: 600;
     grid-column-end: span 2;
     line-height: 1rem;
-    padding: 0.75rem 0;
+    padding: 1.5rem 0 1.25rem;
+    position: sticky;
     text-align: center;
     text-transform: uppercase;
+    top: 0;
+    z-index: 1;
 }
 
 .button {
@@ -84,4 +86,8 @@
  */
 [data-braintree-id='upper-container'] {
     z-index: unset;
+}
+
+:global .braintree-placeholder {
+    display: none;
 }

--- a/packages/venia-concept/src/components/Checkout/paymentsForm.css
+++ b/packages/venia-concept/src/components/Checkout/paymentsForm.css
@@ -22,8 +22,6 @@
     grid-column-end: span 2;
     line-height: 1rem;
     padding: 1.5rem 0 1.25rem;
-    position: -webkit-sticky;
-    position: sticky;
     text-align: center;
     text-transform: uppercase;
     top: 0;

--- a/packages/venia-concept/src/components/Checkout/paymentsForm.css
+++ b/packages/venia-concept/src/components/Checkout/paymentsForm.css
@@ -22,6 +22,7 @@
     grid-column-end: span 2;
     line-height: 1rem;
     padding: 1.5rem 0 1.25rem;
+    position: -webkit-sticky;
     position: sticky;
     text-align: center;
     text-transform: uppercase;
@@ -64,6 +65,10 @@
 .braintree,
 .street0 {
     grid-column-end: span 2;
+}
+
+.braintree {
+    min-height: 356px;
 }
 
 .validation {

--- a/packages/venia-concept/src/components/Checkout/paymentsFormItems.js
+++ b/packages/venia-concept/src/components/Checkout/paymentsFormItems.js
@@ -1,4 +1,4 @@
-import React, { useCallback, Fragment } from 'react';
+import React, { Fragment, useCallback, useEffect, useRef } from 'react';
 import { useFormState } from 'informed';
 import { array, bool, func, shape, string } from 'prop-types';
 
@@ -37,8 +37,10 @@ const PaymentsFormItems = props => {
     // If they resolve it or we move away from informed we can probably get some
     // extra performance.
     const formState = useFormState();
+    const anchorRef = useRef(null);
+    const addressDiffers = formState.values.addresses_same === false;
 
-    const billingAddressFields = !formState.values.addresses_same ? (
+    const billingAddressFields = addressDiffers ? (
         <Fragment>
             <div className={classes.firstname}>
                 <Field label="First Name">
@@ -116,6 +118,7 @@ const PaymentsFormItems = props => {
                     />
                 </Field>
             </div>
+            <span ref={anchorRef} />
         </Fragment>
     ) : null;
 
@@ -158,6 +161,19 @@ const PaymentsFormItems = props => {
         },
         [formState.values, setIsSubmitting, submit]
     );
+
+    // When the address checkbox is unchecked, additional fields are rendered.
+    // This causes the form to grow, and potentially to overflow, so the new
+    // fields may go unnoticed. To reveal them, we scroll them into view.
+    useEffect(() => {
+        if (addressDiffers) {
+            const { current: element } = anchorRef;
+
+            if (element instanceof HTMLElement) {
+                element.scrollIntoView({ behavior: 'smooth' });
+            }
+        }
+    }, [addressDiffers]);
 
     return (
         <Fragment>

--- a/packages/venia-concept/src/components/Checkout/shippingForm.css
+++ b/packages/venia-concept/src/components/Checkout/shippingForm.css
@@ -16,7 +16,7 @@
     font-weight: 600;
     grid-column-end: span 2;
     line-height: 1rem;
-    padding: 0.75rem 0;
+    padding: 1.5rem 0 1.25rem;
     text-align: center;
     text-transform: uppercase;
 }

--- a/packages/venia-concept/src/components/Checkout/shippingForm.css
+++ b/packages/venia-concept/src/components/Checkout/shippingForm.css
@@ -1,24 +1,16 @@
 .root {
 }
 
+.heading {
+    composes: heading from './flow.css';
+}
+
 .body {
-    composes: body from './form.css';
-    grid-gap: 0.5rem;
-    padding: 0 1.5rem;
+    composes: body from './flow.css';
 }
 
 .footer {
-    composes: footer from './form.css';
-}
-
-.heading {
-    font-size: 0.875rem;
-    font-weight: 600;
-    grid-column-end: span 2;
-    line-height: 1rem;
-    padding: 1.5rem 0 1.25rem;
-    text-align: center;
-    text-transform: uppercase;
+    composes: footer from './flow.css';
 }
 
 /* fields */

--- a/packages/venia-concept/src/components/Main/main.css
+++ b/packages/venia-concept/src/components/Main/main.css
@@ -7,8 +7,6 @@
 
 .root_masked {
     composes: root;
-    height: 100vh;
-    overflow: hidden;
 }
 
 .page {

--- a/packages/venia-concept/src/components/Main/main.js
+++ b/packages/venia-concept/src/components/Main/main.js
@@ -1,44 +1,40 @@
-import React, { Component } from 'react';
+import React from 'react';
 import { bool, shape, string } from 'prop-types';
+import { useScrollLock } from '@magento/peregrine';
 
-import classify from 'src/classify';
+import { mergeClasses } from 'src/classify';
 import Footer from 'src/components/Footer';
 import Header from 'src/components/Header';
 import defaultClasses from './main.css';
 
-class Main extends Component {
-    static propTypes = {
-        classes: shape({
-            page: string,
-            page_masked: string,
-            root: string,
-            root_masked: string
-        }),
-        isMasked: bool
-    };
+const Main = props => {
+    const { children, hasBeenOffline, isMasked, isOnline } = props;
+    const classes = mergeClasses(defaultClasses, props.classes);
 
-    get classes() {
-        const { classes, isMasked } = this.props;
-        const suffix = isMasked ? '_masked' : '';
+    const rootClass = isMasked ? classes.root_masked : classes.root;
+    const pageClass = isMasked ? classes.page_masked : classes.page;
 
-        return ['page', 'root'].reduce(
-            (acc, val) => ({ ...acc, [val]: classes[`${val}${suffix}`] }),
-            {}
-        );
-    }
+    useScrollLock(isMasked);
 
-    render() {
-        const { classes, props } = this;
-        const { children, hasBeenOffline, isOnline } = props;
+    return (
+        <main className={rootClass}>
+            <Header hasBeenOffline={hasBeenOffline} isOnline={isOnline} />
+            <div className={pageClass}>{children}</div>
+            <Footer />
+        </main>
+    );
+};
 
-        return (
-            <main className={classes.root}>
-                <Header hasBeenOffline={hasBeenOffline} isOnline={isOnline} />
-                <div className={classes.page}>{children}</div>
-                <Footer />
-            </main>
-        );
-    }
-}
+export default Main;
 
-export default classify(defaultClasses)(Main);
+Main.propTypes = {
+    classes: shape({
+        page: string,
+        page_masked: string,
+        root: string,
+        root_masked: string
+    }),
+    hasBeenOffline: bool,
+    isMasked: bool,
+    isOnline: bool
+};

--- a/packages/venia-concept/src/components/Mask/mask.css
+++ b/packages/venia-concept/src/components/Mask/mask.css
@@ -2,7 +2,7 @@
     background-color: black;
     cursor: pointer;
     display: block;
-    height: 100vh;
+    height: 100%;
     left: 0;
     opacity: 0;
     position: fixed;
@@ -11,7 +11,7 @@
     transition-property: opacity, visibility;
     transition-timing-function: linear;
     visibility: hidden;
-    width: 100vw;
+    width: 100%;
     z-index: 2;
     -webkit-appearance: none;
 }

--- a/packages/venia-concept/src/components/MiniCart/cartOptions.css
+++ b/packages/venia-concept/src/components/MiniCart/cartOptions.css
@@ -1,11 +1,11 @@
 .root {
-    position: inherit;
     display: grid;
-    grid-template-rows: min-content 1fr auto auto;
-    width: 100%;
-    bottom: 0;
-    right: 0;
+    grid-template-rows: min-content 1fr;
+    height: calc(100% - var(--minicart-header-height));
+    left: 0;
+    position: absolute;
     top: 3.5rem;
+    width: 100%;
 }
 
 .focusItem {

--- a/packages/venia-concept/src/components/MiniCart/cartOptions.css
+++ b/packages/venia-concept/src/components/MiniCart/cartOptions.css
@@ -25,7 +25,6 @@
 
 .form {
     overflow: auto;
-    height: 1fr;
 }
 
 .modal {
@@ -62,16 +61,5 @@
 }
 
 .save {
-    box-shadow: 0 -1px rgb(var(--venia-border));
-    background-color: #fff;
-    justify-content: center;
-    padding: 1rem 0;
-    display: flex;
-    width: 100%;
-    overflow: hidden;
-}
-
-.save button {
-    margin-right: 5px;
-    margin-left: 5px;
+    composes: footer from '../../components/Checkout/flow.css';
 }

--- a/packages/venia-concept/src/components/MiniCart/footer.css
+++ b/packages/venia-concept/src/components/MiniCart/footer.css
@@ -1,18 +1,14 @@
-.placeholderButton {
-    text-align: center;
-    margin: 1.5rem 0 1rem 0;
-}
-
 .root {
-    /* This variable is also used by the payments form. */
-    --minicart-footer-padding-bottom: 0.5rem;
-
-    box-shadow: 0 -1px rgb(var(--venia-border));
-    padding: 1.5rem 0 var(--minicart-footer-padding-bottom);
     background-color: white;
+    padding: 0;
 }
 
 .root_open {
     composes: root;
     z-index: 3;
+}
+
+.placeholderButton {
+    text-align: center;
+    margin: 1.5rem 0 1rem 0;
 }

--- a/packages/venia-concept/src/components/MiniCart/miniCart.css
+++ b/packages/venia-concept/src/components/MiniCart/miniCart.css
@@ -1,6 +1,5 @@
 .root {
     --base-z-index: 4;
-    --minicart-height: 100vh;
     --minicart-header-height: 3.5rem;
     align-content: start;
     background-color: white;
@@ -8,7 +7,7 @@
     box-shadow: -1px 0 rgb(var(--venia-border));
     display: grid;
     grid-template-rows: min-content 1fr;
-    height: var(--minicart-height);
+    height: 100%;
     opacity: 0;
     overflow: hidden;
     position: fixed;

--- a/packages/venia-concept/src/components/MiniCart/totalsSummary.css
+++ b/packages/venia-concept/src/components/MiniCart/totalsSummary.css
@@ -1,5 +1,8 @@
 .root {
-    /* Even though this is empty, we leave it in to support overriding. */
+    box-shadow: 0 -1px rgb(var(--venia-border));
+    line-height: 2rem;
+    margin: 0 1.5rem;
+    padding-top: 1.5rem;
 }
 
 .subtotalLabel {

--- a/packages/venia-concept/src/index.css
+++ b/packages/venia-concept/src/index.css
@@ -45,8 +45,10 @@ body {
 
 html[data-scroll-lock='true'],
 html[data-scroll-lock='true'] body {
+    height: 100%;
     overflow: hidden;
     position: fixed;
+    width: 100%;
 }
 
 body,

--- a/packages/venia-concept/src/index.css
+++ b/packages/venia-concept/src/index.css
@@ -43,6 +43,12 @@ body {
     padding: 0;
 }
 
+html[data-scroll-lock='true'],
+html[data-scroll-lock='true'] body {
+    overflow: hidden;
+    position: fixed;
+}
+
 body,
 input,
 select,


### PR DESCRIPTION
## Description

When the app is masked, such as when a drawer or other modal is open, we intend to prevent scrolling at the window level. Currently, we apply styles to the `<Main>`  element to achieve this, but it doesn't work properly in mobile Safari. This PR would shift scroll locking to the `html` and `body` elements as necessary for mobile Safari.

This also resolves a number of visual quirks and inconsistencies in the cart/checkout flow.

- [x] Lock window scrolling and overscrolling when mask is active
- [x] Fit minicart height to viewport in mobile Safari (replace `100vh`)
- [x] Adjust padding in cart footers (decrease)
- [x] Adjust payments form height (decrease)
- [x] Adjust braintree form styles (slightly)
- [x] Adjust checkout subform header padding (increase)
- [x] Adjust padding in cart item editor (increase)
- [x] Fit cart item editor to viewport in mobile Safari (fix auto sizing)

## Related Issue
Closes #1071.

## Verification Steps
1. Open the mobile simulator in Xcode.
2. Go to the deployment of this branch and open the cart.
3. Verify that the window can't be scrolled (or overscrolled) at all.
4. Verify that the cart is not obscured by Safari's chrome.