### PR TITLE
[doc] Update Venia Setup steps

### DIFF
--- a/pwa-devdocs/src/tutorials/cloud-deploy/index.md
+++ b/pwa-devdocs/src/tutorials/cloud-deploy/index.md
@@ -179,7 +179,7 @@ The following table lists the required environment variables for the Venia store
 
 | Name                                 | Value                                                                                                    |
 | ------------------------------------ | -------------------------------------------------------------------------------------------------------- |
-| `CONFIG__DEFAULT__WEB__UPWARD__PATH` | `/app/node_modules/@magento/venia-concept/venia-upward.yml` (absolute path to UPWARD YAML configuration) |
+| `CONFIG__DEFAULT__WEB__UPWARD__PATH` | `/app/node_modules/@magento/venia-concept/upward.yml` (absolute path to UPWARD YAML configuration) |
 | `NODE_ENV`                           | `production`                                                                                             |
 | `MAGENTO_BACKEND_URL`                | `https://[your-cloud-url-here]`                                                                          |
 | `USE_FASTLY`                         | `0 / 1` (dependent on Cloud environment)                                                                 |

--- a/pwa-devdocs/src/venia-pwa-concept/setup/index.md
+++ b/pwa-devdocs/src/venia-pwa-concept/setup/index.md
@@ -36,17 +36,7 @@ In the PWA Studio project's root directory, run the following command to install
 yarn install
 ```
 
-## Step 3. Build the pwa-buildpack package
-
-Setting up Venia requires the use of the `buildpack` CLI tool in the pwa-buildpack package.
-
-Build the pwa-buildpack package to enable the use of this tool:
-
-```sh
-yarn workspace @magento/pwa-buildpack build
-```
-
-## Step 4. Create the `.env` file
+## Step 3. Create the `.env` file
 
 Use the `create-env-file` subcommand for the `buildpack` CLI tool to create a `.env` file for Venia.
 The subcommand generates a `packages/venia-concept/.env` file where you can set the value of `MAGENTO_BACKEND_URL` to the URL of a running Magento instance.
@@ -84,7 +74,7 @@ The Venia storefront has been verified to be compatible with the following local
 
 Don't forget to install the [Venia sample data][]!
 
-## Step 5. Generate SSL certificate
+## Step 4. Generate SSL certificate
 
 PWA features require an HTTPS secure domain.
 
@@ -99,7 +89,7 @@ This feature requires administrative access, so
 it may prompt you for an administrative password at the command line.
 It does not permanently elevate permissions for the dev process but instead, launches a privileged subprocess to execute one command.
 
-## Step 6. Start the server
+## Step 5. Start the server
 
 ### Build artifacts
 


### PR DESCRIPTION
## Description

Removes the third step for building a package in the Venia Setup docs.

Also updates the venia config filename used in the cloud deploy docs.

## Related Issue

Closes #1456 
Closes #1401 

## Verification Steps
<!-- Please describe in detail how a reviewer can verify your changes. -->
1. Navigate to the `pwa-devdocs` directory
2. Build the preview site: `npm run develop`
3. Navigate to `/venia-pwa-concept/setup/`
4. Verify the modified steps still work on a **fresh** clone of pwa-studio

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly, if necessary.
- [ ] I have added tests to cover my changes, if necessary.
