### PR TITLE
[BUGFIX] Fix #1477 to be more consistant with the rest of the venia d…

### DIFF
--- a/packages/venia-concept/src/components/FilterModal/filterModal.css
+++ b/packages/venia-concept/src/components/FilterModal/filterModal.css
@@ -1,24 +1,25 @@
 .root {
-    position: fixed;
-    left: 0;
-    bottom: 0;
-    right: 0;
     background-color: white;
-    transform: translate3d(0, 100%, 0);
-    transition-duration: 192ms;
-    transition-timing-function: var(--venia-anim-out);
-    transition-property: opacity, transform, visibility;
-    visibility: hidden;
-    opacity: 0;
-    overflow: hidden;
-    width: 100%;
-    z-index: 3;
+    bottom: 0;
     display: grid;
     grid-template-rows: min-content 1fr;
-    height: 100%;
+    left: 0;
+    opacity: 0;
+    position: fixed;
+    top: 0;
+    transform: translate3d(-100%, 0, 0);
+    transition-duration: 192ms;
+    transition-timing-function: cubic-bezier(0.4, 0, 1, 1);
+    transition-property: opacity, transform, visibility;
+    visibility: hidden;
+    width: 100%;
+    max-width: 360px;
+    z-index: 3;
 }
 
-.rootOpen {
+/* state: open */
+
+.root_open {
     composes: root;
     box-shadow: 1px 0 rgb(var(--venia-border));
     opacity: 1;

--- a/packages/venia-concept/src/components/FilterModal/filterModal.js
+++ b/packages/venia-concept/src/components/FilterModal/filterModal.js
@@ -14,6 +14,7 @@ class FilterModal extends Component {
     static propTypes = {
         classes: PropTypes.shape({
             root: PropTypes.string,
+            root_open: PropTypes.string,
             modalWrapper: PropTypes.string,
             header: PropTypes.string,
             headerTitle: PropTypes.string,
@@ -41,7 +42,7 @@ class FilterModal extends Component {
     render() {
         const { classes, drawer, closeDrawer } = this.props;
         const modalClass =
-            drawer === 'filter' ? classes.rootOpen : classes.root;
+            drawer === 'filter' ? classes.root_open : classes.root;
 
         return (
             <Modal>


### PR DESCRIPTION
## Description
The animation / drawer styling is now the same as other drawers like the navigation.
Also changed .rootOpen to .root_open to be more consistent with venia.

<!--- Using the above wording causes Github to automatically close the issue on merge. -->
Closes #1477.

## Proposed Labels for Change Type/Package
<!--- What type of change level would you suggest for this PR? -->
<!--- Major, Minor, or Patch? -->
<!--- See https://magento-research.github.io/pwa-studio/technologies/versioning/ for help -->
- [ ] major (e.g x.0.0 - a breaking change)
- [ ] minor (e.g 0.x.0 - a backwards compatible addition)
- [x] patch (e.g 0.0.x - a bug fix)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly, if necessary.
- [x] I have added tests to cover my changes, if necessary.
