### PR TITLE
Add migration banner

### DIFF
--- a/pwa-devdocs/src/_includes/layout/pre-release-banner.html
+++ b/pwa-devdocs/src/_includes/layout/pre-release-banner.html
@@ -1,4 +1,6 @@
-<div class="message-banner">
-If you have any project questions, concerns, or contribution ideas, join our <a href="https://magentocommeng.slack.com/messages/C71HNKYS2"><strong>#pwa</strong></a> Slack channel.
-Find out how to create an account by visiting <a href="https://devdocs.magento.com/community/resources/resources.html">Community Resources</a>
+<div class="message-banner warning-banner">
+    The <a href="https://github.com/magento-research/pwa-studio">PWA Studio repository</a> is moving to a new GitHub organization!
+    As a result, the URL for this site is also changing to <a href="https://magento.github.io/pwa-studio/">https://magento.github.io/pwa-studio/</a>.
+    <br/>
+    If you have any questions or concerns, let us know in our <a href="https://magentocommeng.slack.com/messages/C71HNKYS2"><strong>#pwa</strong></a> Slack channel.
 </div>

--- a/pwa-devdocs/src/_includes/layout/pre-release-banner.html
+++ b/pwa-devdocs/src/_includes/layout/pre-release-banner.html
@@ -1,6 +1,6 @@
 <div class="message-banner warning-banner">
     The <a href="https://github.com/magento-research/pwa-studio">PWA Studio repository</a> is moving to a new GitHub organization!
-    As a result, the URL for this site is also changing to <a href="https://magento.github.io/pwa-studio/">https://magento.github.io/pwa-studio/</a>.
+    As a result, the URL for this site is also changing. Please use <a href="https://pwastudio.io">https://pwastudio.io"</a> going forward.
     <br/>
     If you have any questions or concerns, let us know in our <a href="https://magentocommeng.slack.com/messages/C71HNKYS2"><strong>#pwa</strong></a> Slack channel.
 </div>

--- a/pwa-devdocs/src/_scss/src/_message-banner.scss
+++ b/pwa-devdocs/src/_scss/src/_message-banner.scss
@@ -5,3 +5,8 @@
   border-right: none;
   border-top: none;
 }
+
+.warning-banner {
+  background-color: #FFF1AD;
+  color: #666666
+}


### PR DESCRIPTION
## Description

Adds a highly visible banner notifying visitors of the switch to a new URL.

## Related Issue

Closes #1491 

## Verification Steps

1. Navigate to the `pwa-devdocs` directory
2. Build the HTML preview: `npm run develop`
3. Verify the new banner appears at the top of multiple pages.