### PR TITLE
[doc] Restore banner's original content

### DIFF
--- a/pwa-devdocs/src/_includes/layout/pre-release-banner.html
+++ b/pwa-devdocs/src/_includes/layout/pre-release-banner.html
@@ -1,6 +1,4 @@
-<div class="message-banner warning-banner">
-    The <a href="https://github.com/magento-research/pwa-studio">PWA Studio repository</a> is moving to a new GitHub organization!
-    As a result, the URL for this site is also changing. Please use <a href="https://pwastudio.io">https://pwastudio.io"</a> going forward.
-    <br/>
-    If you have any questions or concerns, let us know in our <a href="https://magentocommeng.slack.com/messages/C71HNKYS2"><strong>#pwa</strong></a> Slack channel.
+<div class="message-banner">
+If you have any project questions, concerns, or contribution ideas, join our <a href="https://magentocommeng.slack.com/messages/C71HNKYS2"><strong>#pwa</strong></a> Slack channel.
+Find out how to create an account by visiting <a href="https://devdocs.magento.com/community/resources/resources.html">Community Resources</a>
 </div>


### PR DESCRIPTION

## Description

This PR will remove the migration message and restore the message to the previous one.

## Related Issue

Closes #ISSUE_NUMBER.

## Verification Steps

1. Navigate to the pwa-devdocs directory
2. Build the preview HTML: `npm run develop`
3. Verify the blue banner is back with original message.

## Screenshots / Screen Captures (if appropriate)
n/a
